### PR TITLE
Fix crash after sending funds by doing some code cleanup.

### DIFF
--- a/app/src/main/java/com/greenaddress/greenbits/ui/ActionBarActivity.java
+++ b/app/src/main/java/com/greenaddress/greenbits/ui/ActionBarActivity.java
@@ -1,0 +1,14 @@
+package com.greenaddress.greenbits.ui;
+
+import com.greenaddress.greenbits.GaService;
+import com.greenaddress.greenbits.GreenAddressApplication;
+
+public abstract class ActionBarActivity extends android.support.v7.app.ActionBarActivity {
+    protected GreenAddressApplication getGAApp() {
+        return (GreenAddressApplication) getApplication();
+    }
+
+    protected GaService getGAService() {
+        return getGAApp().gaService;
+    }
+}

--- a/app/src/main/java/com/greenaddress/greenbits/ui/FirstScreenActivity.java
+++ b/app/src/main/java/com/greenaddress/greenbits/ui/FirstScreenActivity.java
@@ -3,7 +3,6 @@ package com.greenaddress.greenbits.ui;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
-import android.support.v7.app.ActionBarActivity;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -11,7 +10,6 @@ import android.widget.Button;
 import android.widget.TextView;
 
 import com.greenaddress.greenbits.ConnectivityObservable;
-import com.greenaddress.greenbits.GreenAddressApplication;
 
 import java.util.Observable;
 import java.util.Observer;
@@ -76,9 +74,9 @@ public class FirstScreenActivity extends ActionBarActivity implements Observer {
     @Override
     public void onResume() {
         super.onResume();
-        ((GreenAddressApplication) getApplication()).getConnectionObservable().addObserver(this);
+        getGAApp().getConnectionObservable().addObserver(this);
 
-        final ConnectivityObservable.State state = ((GreenAddressApplication) getApplication()).getConnectionObservable().getState();
+        final ConnectivityObservable.State state = getGAApp().getConnectionObservable().getState();
         if (state.equals(ConnectivityObservable.State.LOGGEDIN) || state.equals(ConnectivityObservable.State.LOGGINGIN)) {
             // already logged in, could be from different app via intent
             final Intent mainActivity = new Intent(FirstScreenActivity.this, TabbedMainActivity.class);
@@ -96,7 +94,7 @@ public class FirstScreenActivity extends ActionBarActivity implements Observer {
     @Override
     public void onPause() {
         super.onPause();
-        ((GreenAddressApplication) getApplication()).getConnectionObservable().deleteObserver(this);
+        getGAApp().getConnectionObservable().deleteObserver(this);
     }
 
     @Override

--- a/app/src/main/java/com/greenaddress/greenbits/ui/GAFragment.java
+++ b/app/src/main/java/com/greenaddress/greenbits/ui/GAFragment.java
@@ -1,5 +1,6 @@
 package com.greenaddress.greenbits.ui;
 
+import android.app.Activity;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
@@ -7,13 +8,23 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
+import com.greenaddress.greenbits.GaService;
 import com.greenaddress.greenbits.GreenAddressApplication;
 
 abstract public class GAFragment extends Fragment {
+    private GreenAddressApplication gaApp;
+
+    @Override
+    public void onAttach(Activity activity) {
+        super.onAttach(activity);
+
+        gaApp = (GreenAddressApplication) activity.getApplication();
+    }
+
     @Override
     public void onResume() {
         super.onResume();
-        if (((GreenAddressApplication) getActivity().getApplication()).gaService == null) {
+        if (getGAService() == null) {
             getActivity().finish();
             return;
         }
@@ -27,7 +38,7 @@ abstract public class GAFragment extends Fragment {
 
     @Override
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
-        if (((GreenAddressApplication) getActivity().getApplication()).gaService == null) {
+        if (getGAService() == null) {
             getActivity().finish();
             return null;
         }
@@ -41,4 +52,15 @@ abstract public class GAFragment extends Fragment {
 
     abstract View onGACreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState);
     void onGAResume() { };
+
+    protected GreenAddressApplication getGAApp() {
+        return gaApp;
+    }
+
+    protected GaService getGAService() {
+        if (gaApp != null) {
+            return gaApp.gaService;
+        }
+        return null;
+    }
 }

--- a/app/src/main/java/com/greenaddress/greenbits/ui/MnemonicActivity.java
+++ b/app/src/main/java/com/greenaddress/greenbits/ui/MnemonicActivity.java
@@ -8,7 +8,6 @@ import android.nfc.NdefMessage;
 import android.nfc.NfcAdapter;
 import android.os.Bundle;
 import android.os.Parcelable;
-import android.support.v7.app.ActionBarActivity;
 import android.text.Spannable;
 import android.text.SpannableString;
 import android.text.TextUtils;
@@ -40,7 +39,6 @@ import com.google.common.util.concurrent.SettableFuture;
 import com.greenaddress.greenapi.LoginData;
 import com.greenaddress.greenbits.ConnectivityObservable;
 import com.greenaddress.greenbits.GaService;
-import com.greenaddress.greenbits.GreenAddressApplication;
 import com.lambdaworks.crypto.SCrypt;
 
 import org.bitcoinj.core.Sha256Hash;
@@ -176,7 +174,7 @@ public class MnemonicActivity extends ActionBarActivity implements Observer {
 
 
     private void login() {
-        Futures.addCallback(((GreenAddressApplication) getApplication()).onServiceConnected, new FutureCallback<Void>() {
+        Futures.addCallback(getGAApp().onServiceConnected, new FutureCallback<Void>() {
             @Override
             public void onSuccess(@Nullable Void result) {
                 loginAfterServiceConnected();
@@ -191,8 +189,8 @@ public class MnemonicActivity extends ActionBarActivity implements Observer {
     }
 
     private void loginAfterServiceConnected() {
-        final GaService gaService = ((GreenAddressApplication) getApplication()).gaService;
-        if (((GreenAddressApplication) getApplication()).getConnectionObservable().getState() != ConnectivityObservable.State.CONNECTED) {
+        final GaService gaService = getGAService();
+        if (getGAApp().getConnectionObservable().getState() != ConnectivityObservable.State.CONNECTED) {
             Toast.makeText(MnemonicActivity.this, "Not connected", Toast.LENGTH_LONG).show();
             return;
         }
@@ -367,7 +365,7 @@ public class MnemonicActivity extends ActionBarActivity implements Observer {
                     final String mnemonics = TextUtils.join(" ",
                             new MnemonicCode(closable, null)
                                     .toMnemonic(array));
-                    final GaService gaService = ((GreenAddressApplication) getApplication()).gaService;
+                    final GaService gaService = getGAService();
                     edit.setText(mnemonics);
 
                     if (gaService != null && gaService.onConnected != null && !mnemonics.equals(gaService.getMnemonics())) {
@@ -406,7 +404,7 @@ public class MnemonicActivity extends ActionBarActivity implements Observer {
                     public void onSuccess(@Nullable String passphrase) {
                         try {
                             byte[] decrypted = decryptMnemonic(array, passphrase);
-                            final GaService gaService = ((GreenAddressApplication) getApplication()).gaService;
+                            final GaService gaService = getGAService();
                             final String mnemonics = Joiner.on(" ").join(new MnemonicCode().toMnemonic(decrypted));
                             edit.setText(mnemonics);
                             if (gaService != null && gaService.onConnected != null && !mnemonics.equals(gaService.getMnemonics())) {
@@ -440,9 +438,9 @@ public class MnemonicActivity extends ActionBarActivity implements Observer {
     @Override
     protected void onResume() {
         super.onResume();
-        ((GreenAddressApplication) getApplication()).getConnectionObservable().addObserver(this);
+        getGAApp().getConnectionObservable().addObserver(this);
 
-        ConnectivityObservable.State state = ((GreenAddressApplication) getApplication()).getConnectionObservable().getState();
+        ConnectivityObservable.State state = getGAApp().getConnectionObservable().getState();
         if (state.equals(ConnectivityObservable.State.LOGGEDIN)) {
             // already logged in, could be from different app via intent
             final Intent mainActivity = new Intent(MnemonicActivity.this, TabbedMainActivity.class);
@@ -456,7 +454,7 @@ public class MnemonicActivity extends ActionBarActivity implements Observer {
     @Override
     public void onPause() {
         super.onPause();
-        ((GreenAddressApplication) getApplication()).getConnectionObservable().deleteObserver(this);
+        getGAApp().getConnectionObservable().deleteObserver(this);
     }
 
 

--- a/app/src/main/java/com/greenaddress/greenbits/ui/PinActivity.java
+++ b/app/src/main/java/com/greenaddress/greenbits/ui/PinActivity.java
@@ -3,7 +3,6 @@ package com.greenaddress.greenbits.ui;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Bundle;
-import android.support.v7.app.ActionBarActivity;
 import android.view.KeyEvent;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -25,7 +24,6 @@ import com.greenaddress.greenbits.GaService;
 import com.greenaddress.greenapi.GAException;
 import com.greenaddress.greenapi.LoginData;
 import com.greenaddress.greenapi.PinData;
-import com.greenaddress.greenbits.GreenAddressApplication;
 
 import java.util.Observable;
 import java.util.Observer;
@@ -38,7 +36,7 @@ public class PinActivity extends ActionBarActivity implements Observer {
     private Menu menu;
 
     private void login(final CircularProgressButton pinLoginButton, final String ident, final EditText pinText, final TextView pinError) {
-        Futures.addCallback(((GreenAddressApplication) getApplication()).onServiceConnected, new FutureCallback<Void>() {
+        Futures.addCallback(getGAApp().onServiceConnected, new FutureCallback<Void>() {
             @Override
             public void onSuccess(@Nullable Void result) {
                 loginAfterServiceConnected(pinLoginButton, ident, pinText, pinError);
@@ -53,12 +51,12 @@ public class PinActivity extends ActionBarActivity implements Observer {
     }
 
     private void loginAfterServiceConnected(final CircularProgressButton pinLoginButton, final String ident, final EditText pinText, final TextView pinError) {
-        if (!((GreenAddressApplication) getApplication()).getConnectionObservable().getState().equals(ConnectivityObservable.State.CONNECTED)) {
+        if (!getGAApp().getConnectionObservable().getState().equals(ConnectivityObservable.State.CONNECTED)) {
             Toast.makeText(PinActivity.this, "Not connected, connection will resume automatically", Toast.LENGTH_LONG).show();
             return;
         }
 
-        final GaService gaService = ((GreenAddressApplication) getApplication()).gaService;
+        final GaService gaService = getGAService();
 
         final PinData pinData = new PinData(ident,
                 getSharedPreferences("pin", MODE_PRIVATE).getString("encrypted", null));
@@ -178,9 +176,9 @@ public class PinActivity extends ActionBarActivity implements Observer {
     @Override
     public void onResume() {
         super.onResume();
-        ((GreenAddressApplication) getApplication()).getConnectionObservable().addObserver(this);
+        getGAApp().getConnectionObservable().addObserver(this);
 
-        if (((GreenAddressApplication) getApplication()).getConnectionObservable().getState().equals(ConnectivityObservable.State.LOGGEDIN) || ((GreenAddressApplication) getApplication()).getConnectionObservable().getState().equals(ConnectivityObservable.State.LOGGINGIN)) {
+        if (getGAApp().getConnectionObservable().getState().equals(ConnectivityObservable.State.LOGGEDIN) || getGAApp().getConnectionObservable().getState().equals(ConnectivityObservable.State.LOGGINGIN)) {
             // already logged in, could be from different app via intent
             final Intent mainActivity = new Intent(PinActivity.this, TabbedMainActivity.class);
             startActivity(mainActivity);
@@ -193,7 +191,7 @@ public class PinActivity extends ActionBarActivity implements Observer {
     @Override
     public void onPause() {
         super.onPause();
-        ((GreenAddressApplication) getApplication()).getConnectionObservable().deleteObserver(this);
+        getGAApp().getConnectionObservable().deleteObserver(this);
     }
 
 
@@ -225,7 +223,7 @@ public class PinActivity extends ActionBarActivity implements Observer {
         // as you specify a parent activity in AndroidManifest.xml.
         int id = item.getItemId();
         if (id == R.id.network_unavailable) {
-            Toast.makeText(PinActivity.this, ((GreenAddressApplication) getApplication()).getConnectionObservable().getState().toString() , Toast.LENGTH_LONG).show();
+            Toast.makeText(PinActivity.this, getGAApp().getConnectionObservable().getState().toString() , Toast.LENGTH_LONG).show();
             return true;
         }
         return super.onOptionsItemSelected(item);
@@ -234,7 +232,7 @@ public class PinActivity extends ActionBarActivity implements Observer {
     @Override
     public void update(final Observable observable, final Object data) {
         // connectivity changed
-        final ConnectivityObservable.State currentState = ((GreenAddressApplication) getApplication()).getConnectionObservable().getState();
+        final ConnectivityObservable.State currentState = getGAApp().getConnectionObservable().getState();
         if (menu != null) {
             setPlugVisible(currentState != ConnectivityObservable.State.CONNECTED && currentState != ConnectivityObservable.State.LOGGEDIN && currentState != ConnectivityObservable.State.LOGGINGIN);
         }

--- a/app/src/main/java/com/greenaddress/greenbits/ui/PinSaveActivity.java
+++ b/app/src/main/java/com/greenaddress/greenbits/ui/PinSaveActivity.java
@@ -3,7 +3,6 @@ package com.greenaddress.greenbits.ui;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Bundle;
-import android.support.v7.app.ActionBarActivity;
 import android.view.KeyEvent;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -18,7 +17,6 @@ import com.dd.CircularProgressButton;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.greenaddress.greenapi.PinData;
-import com.greenaddress.greenbits.GreenAddressApplication;
 
 import org.bitcoinj.crypto.MnemonicCode;
 
@@ -43,7 +41,7 @@ public class PinSaveActivity extends ActionBarActivity implements Observer {
         pinSaveButton.setIndeterminateProgressMode(true);
         pinSaveButton.setProgress(50);
         pinSkipButton.setVisibility(View.GONE);
-        Futures.addCallback(((GreenAddressApplication) getApplication()).gaService.setPin(MnemonicCode.toSeed(mnemonic, ""), mnemonic_str,
+        Futures.addCallback(getGAService().setPin(MnemonicCode.toSeed(mnemonic, ""), mnemonic_str,
                         pinText.getText().toString(), "default"),
                 new FutureCallback<PinData>() {
                     @Override
@@ -69,19 +67,19 @@ public class PinSaveActivity extends ActionBarActivity implements Observer {
                             }
                         });
                     }
-                }, ((GreenAddressApplication) getApplication()).gaService.es);
+                }, getGAService().es);
     }
     @Override
     public void onResume() {
         super.onResume();
 
-        ((GreenAddressApplication) getApplication()).getConnectionObservable().addObserver(this);
+        getGAApp().getConnectionObservable().addObserver(this);
     }
 
     @Override
     public void onPause() {
         super.onPause();
-        ((GreenAddressApplication) getApplication()).getConnectionObservable().deleteObserver(this);
+        getGAApp().getConnectionObservable().deleteObserver(this);
     }
     @Override
     protected void onCreate(final Bundle savedInstanceState) {

--- a/app/src/main/java/com/greenaddress/greenbits/ui/ReceiveFragment.java
+++ b/app/src/main/java/com/greenaddress/greenbits/ui/ReceiveFragment.java
@@ -29,7 +29,6 @@ import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.greenaddress.greenbits.ConnectivityObservable;
-import com.greenaddress.greenbits.GreenAddressApplication;
 import com.greenaddress.greenbits.QrBitmap;
 
 import javax.annotation.Nullable;
@@ -61,8 +60,8 @@ public class ReceiveFragment extends GAFragment {
             // get a new address every time the tab is displayed
             if (isVisibleToUser) {
                 // get a new address:
-                final ListenableFuture<QrBitmap> ft = ((GreenAddressApplication) getActivity().getApplication()).gaService.getNewAddress(curSubaccount);
-                Futures.addCallback(ft, onAddress, ((GreenAddressApplication) getActivity().getApplication()).gaService.es);
+                final ListenableFuture<QrBitmap> ft = getGAService().getNewAddress(curSubaccount);
+                Futures.addCallback(ft, onAddress, getGAService().es);
                 startNewAddressAnimation(rootView);
             } else { // !isVisibleToUser
                 // hide to avoid showing old address when swiping
@@ -95,7 +94,7 @@ public class ReceiveFragment extends GAFragment {
             address = savedInstanceState.getParcelable("address");
         }
 
-        curSubaccount = getActivity().getSharedPreferences("receive", Context.MODE_PRIVATE).getInt("curSubaccount", 0);
+        curSubaccount = getGAApp().getSharedPreferences("receive", Context.MODE_PRIVATE).getInt("curSubaccount", 0);
 
         final View rootView = inflater.inflate(R.layout.fragment_receive, container, false);
         final TextView receiveAddress = (TextView) rootView.findViewById(R.id.receiveAddressText);
@@ -208,19 +207,19 @@ public class ReceiveFragment extends GAFragment {
                 new View.OnClickListener() {
                     @Override
                     public void onClick(final View view) {
-                        if (!((GreenAddressApplication) getActivity().getApplication()).getConnectionObservable().getState().equals(ConnectivityObservable.State.LOGGEDIN)) {
+                        if (!getGAApp().getConnectionObservable().getState().equals(ConnectivityObservable.State.LOGGEDIN)) {
                             Toast.makeText(getActivity(), "Not connected, connection will resume automatically", Toast.LENGTH_LONG).show();
                             return;
                         }
                         startNewAddressAnimation(rootView);
 
-                        final ListenableFuture<QrBitmap> ft = ((GreenAddressApplication) getActivity().getApplication()).gaService.getNewAddress(curSubaccount);
-                        Futures.addCallback(ft, onAddress, ((GreenAddressApplication) getActivity().getApplication()).gaService.es);
+                        final ListenableFuture<QrBitmap> ft = getGAService().getNewAddress(curSubaccount);
+                        Futures.addCallback(ft, onAddress, getGAService().es);
                     }
                 }
         );
 
-        ((GreenAddressApplication) getActivity().getApplication()).configureSubaccountsFooter(
+        getGAApp().configureSubaccountsFooter(
                 curSubaccount,
                 getActivity(),
                 (TextView) rootView.findViewById(R.id.sendAccountName),
@@ -231,13 +230,13 @@ public class ReceiveFragment extends GAFragment {
                     @Override
                     public Void apply(@Nullable Integer input) {
                         curSubaccount = input;
-                        final SharedPreferences.Editor editor = getActivity().getSharedPreferences("receive", Context.MODE_PRIVATE).edit();
+                        final SharedPreferences.Editor editor = getGAApp().getSharedPreferences("receive", Context.MODE_PRIVATE).edit();
                         editor.putInt("curSubaccount", curSubaccount);
                         editor.apply();
                         startNewAddressAnimation(rootView);
                         Futures.addCallback(
-                                ((GreenAddressApplication) getActivity().getApplication()).gaService.getLatestOrNewAddress(curSubaccount),
-                                onAddress, ((GreenAddressApplication) getActivity().getApplication()).gaService.es);
+                                getGAService().getLatestOrNewAddress(curSubaccount),
+                                onAddress, getGAService().es);
                         return null;
                     }
                 },
@@ -274,6 +273,7 @@ public class ReceiveFragment extends GAFragment {
         final ImageView imageView = (ImageView) rootView.findViewById(R.id.receiveQrImageView);
         copyIcon.setVisibility(View.GONE);
         copyText.setVisibility(View.GONE);
+        receiveAddress.setText("");
         receiveAddress.setText("");
         imageView.setImageBitmap(null);
     }

--- a/app/src/main/java/com/greenaddress/greenbits/ui/RequestLoginActivity.java
+++ b/app/src/main/java/com/greenaddress/greenbits/ui/RequestLoginActivity.java
@@ -51,7 +51,7 @@ public class RequestLoginActivity extends Activity implements Observer {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_first_login_requested);
 
-        ((GreenAddressApplication) getApplication()).getConnectionObservable().addObserver(this);
+        getGAApp().getConnectionObservable().addObserver(this);
 
         Tag tag = (Tag) getIntent().getParcelableExtra(NfcAdapter.EXTRA_TAG);
 
@@ -164,10 +164,10 @@ public class RequestLoginActivity extends Activity implements Observer {
                     instructions.setText(getResources().getString(R.string.firstLoginRequestedInstructionsOldTrezor));
                     return;
                 }
-                Futures.addCallback(((GreenAddressApplication) getApplication()).onServiceConnected, new FutureCallback<Void>() {
+                Futures.addCallback(getGAApp().onServiceConnected, new FutureCallback<Void>() {
                     @Override
                     public void onSuccess(@Nullable Void result) {
-                        final GaService gaService = ((GreenAddressApplication) getApplication()).gaService;
+                        final GaService gaService = getGAService();
 
                         Futures.addCallback(Futures.transform(gaService.onConnected, new AsyncFunction<Void, LoginData>() {
                             @Override
@@ -318,10 +318,10 @@ public class RequestLoginActivity extends Activity implements Observer {
             transport = new BTChipTransportAndroidNFC(isoDep);
             transport.setDebug(true);
         }
-        Futures.addCallback(((GreenAddressApplication) getApplication()).onServiceConnected, new FutureCallback<Void>() {
+        Futures.addCallback(getGAApp().onServiceConnected, new FutureCallback<Void>() {
             @Override
             public void onSuccess(@Nullable Void result) {
-                final GaService gaService = ((GreenAddressApplication) getApplication()).gaService;
+                final GaService gaService = getGAService();
 
                 Futures.addCallback(Futures.transform(gaService.onConnected, new AsyncFunction<Void, LoginData>() {
                     @Override
@@ -389,17 +389,25 @@ public class RequestLoginActivity extends Activity implements Observer {
     public void onResume() {
         super.onResume();
 
-        ((GreenAddressApplication) getApplication()).getConnectionObservable().addObserver(this);
+        getGAApp().getConnectionObservable().addObserver(this);
     }
 
     @Override
     public void onPause() {
         super.onPause();
-        ((GreenAddressApplication) getApplication()).getConnectionObservable().deleteObserver(this);
+        getGAApp().getConnectionObservable().deleteObserver(this);
     }
 
     @Override
     public void update(Observable observable, Object data) {
 
+    }
+
+    protected GreenAddressApplication getGAApp() {
+        return (GreenAddressApplication) getApplication();
+    }
+
+    protected GaService getGAService() {
+        return getGAApp().gaService;
     }
 }

--- a/app/src/main/java/com/greenaddress/greenbits/ui/SignUpActivity.java
+++ b/app/src/main/java/com/greenaddress/greenbits/ui/SignUpActivity.java
@@ -15,7 +15,6 @@ import android.nfc.tech.Ndef;
 import android.nfc.tech.NdefFormatable;
 import android.os.Build;
 import android.os.Bundle;
-import android.support.v7.app.ActionBarActivity;
 import android.text.method.LinkMovementMethod;
 import android.util.DisplayMetrics;
 import android.util.Log;
@@ -41,7 +40,6 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.greenaddress.greenapi.LoginData;
 import com.greenaddress.greenbits.GaService;
-import com.greenaddress.greenbits.GreenAddressApplication;
 import com.greenaddress.greenbits.QrBitmap;
 
 import org.bitcoinj.crypto.MnemonicException;
@@ -90,7 +88,7 @@ public class SignUpActivity extends ActionBarActivity implements Observer {
 
         final TextView qrCodeIcon = (TextView) findViewById(R.id.signupQrCodeIcon);
         final ImageView qrcodeMnemonic = (ImageView) inflatedLayout.findViewById(R.id.qrInDialogImageView);
-        final ListenableFuture<String> mnemonicPassphrase = ((GreenAddressApplication) getApplication()).gaService.getMnemonicPassphrase();
+        final ListenableFuture<String> mnemonicPassphrase = getGAService().getMnemonicPassphrase();
         Futures.addCallback(mnemonicPassphrase, new FutureCallback<String>() {
             @Override
             public void onSuccess(@Nullable final String result) {
@@ -106,14 +104,14 @@ public class SignUpActivity extends ActionBarActivity implements Observer {
             public void onFailure(final Throwable t) {
 
             }
-        }, ((GreenAddressApplication) getApplication()).gaService.es);
+        }, getGAService().es);
 
         qrCodeIcon.setOnClickListener(new View.OnClickListener() {
             public void onClick(final View view) {
                 final Animation iconPressed = AnimationUtils.loadAnimation(SignUpActivity.this, R.anim.rotation);
                 qrCodeIcon.startAnimation(iconPressed);
 
-                final ListenableFuture<QrBitmap> mnemonicQrcode = ((GreenAddressApplication) getApplication()).gaService.getQrCodeForMnemonicPassphrase();
+                final ListenableFuture<QrBitmap> mnemonicQrcode = getGAService().getQrCodeForMnemonicPassphrase();
                 Futures.addCallback(mnemonicQrcode, new FutureCallback<QrBitmap>() {
 
                     @Override
@@ -148,17 +146,17 @@ public class SignUpActivity extends ActionBarActivity implements Observer {
                     public void onFailure(final Throwable t) {
 
                     }
-                }, ((GreenAddressApplication) getApplication()).gaService.es);
+                }, getGAService().es);
             }
         });
 
-        final GaService gaService = ((GreenAddressApplication) getApplication()).gaService;
+        final GaService gaService = getGAService();
 
         checkBox.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
             @Override
             public void onCheckedChanged(final CompoundButton compoundButton, final boolean isChecked) {
                 if (onSignUp == null) {
-                    if (((GreenAddressApplication) getApplication()).gaService.onConnected != null) {
+                    if (getGAService().onConnected != null) {
                         signupContinueButton.setEnabled(true);
                         checkBox.setEnabled(false);
                         onSignUp = Futures.transform(gaService.onConnected, new AsyncFunction<Void, LoginData>() {
@@ -203,7 +201,7 @@ public class SignUpActivity extends ActionBarActivity implements Observer {
                             final Intent pinSaveActivity = new Intent(SignUpActivity.this, PinSaveActivity.class);
 
                             pinSaveActivity.putExtra("com.greenaddress.greenbits.NewPinMnemonic", gaService.getMnemonics());
-                            ((GreenAddressApplication) getApplication()).gaService.resetSignUp();
+                            getGAService().resetSignUp();
                             onSignUp = null;
                             finish();
                             startActivity(pinSaveActivity);
@@ -219,7 +217,7 @@ public class SignUpActivity extends ActionBarActivity implements Observer {
                                 }
                             });
                         }
-                    }, ((GreenAddressApplication) getApplication()).gaService.es);
+                    }, getGAService().es);
                 } else {
                     if (!checkBox.isChecked()) {
                         SignUpActivity.this.runOnUiThread(new Runnable() {
@@ -275,7 +273,7 @@ public class SignUpActivity extends ActionBarActivity implements Observer {
             mNfcAdapter.enableForegroundDispatch(this, mNfcPendingIntent, new IntentFilter[] { new IntentFilter(NfcAdapter.ACTION_TAG_DISCOVERED)}, null);
         }
         signupNfcIcon.setVisibility(mNfcAdapter != null && mNfcAdapter.isEnabled() ? View.VISIBLE : View.GONE);
-        ((GreenAddressApplication) getApplication()).getConnectionObservable().addObserver(this);
+        getGAApp().getConnectionObservable().addObserver(this);
     }
 
     @Override
@@ -284,7 +282,7 @@ public class SignUpActivity extends ActionBarActivity implements Observer {
         if (mNfcAdapter != null) {
             mNfcAdapter.disableForegroundDispatch(this);
         }
-        ((GreenAddressApplication) getApplication()).getConnectionObservable().deleteObserver(this);
+        getGAApp().getConnectionObservable().deleteObserver(this);
 
     }
 
@@ -297,7 +295,7 @@ public class SignUpActivity extends ActionBarActivity implements Observer {
             final Tag detectedTag = intent.getParcelableExtra(NfcAdapter.EXTRA_TAG);
             NdefRecord record = null;
             try {
-                record = NdefRecord.createMime("x-gait/mnc", ((GreenAddressApplication) getApplication()).gaService.getEntropyFromMnemonics(mnemonicText.getText().toString()));
+                record = NdefRecord.createMime("x-gait/mnc", getGAService().getEntropyFromMnemonics(mnemonicText.getText().toString()));
             } catch (final IOException | MnemonicException.MnemonicChecksumException | MnemonicException.MnemonicLengthException | MnemonicException.MnemonicWordException e ) {
             }
 
@@ -356,9 +354,9 @@ public class SignUpActivity extends ActionBarActivity implements Observer {
     @Override
     public void onBackPressed() {
         if (onSignUp != null) {
-            ((GreenAddressApplication) getApplication()).gaService.resetSignUp();
+            getGAService().resetSignUp();
             onSignUp = null;
-            ((GreenAddressApplication) getApplication()).gaService.disconnect(true);
+            getGAService().disconnect(true);
         }
         super.onBackPressed();
     }

--- a/app/src/main/java/com/greenaddress/greenbits/ui/TransactionActivity.java
+++ b/app/src/main/java/com/greenaddress/greenbits/ui/TransactionActivity.java
@@ -2,7 +2,6 @@ package com.greenaddress.greenbits.ui;
 
 import android.content.Intent;
 import android.os.Bundle;
-import android.support.v7.app.ActionBarActivity;
 import android.text.Html;
 import android.text.method.LinkMovementMethod;
 import android.view.LayoutInflater;
@@ -13,7 +12,6 @@ import android.view.ViewGroup;
 import android.widget.TextView;
 
 import com.greenaddress.greenapi.Network;
-import com.greenaddress.greenbits.GreenAddressApplication;
 
 import org.bitcoinj.core.Coin;
 import org.bitcoinj.utils.MonetaryFormat;
@@ -31,7 +29,7 @@ public class TransactionActivity extends ActionBarActivity implements Observer {
     @Override
     protected void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        if (((GreenAddressApplication) getApplication()).gaService == null) {
+        if (getGAService() == null) {
             finish();
             return;
         }
@@ -118,12 +116,12 @@ public class TransactionActivity extends ActionBarActivity implements Observer {
                         rootView.findViewById(R.id.txUnconfirmed).setVisibility(View.GONE);
                     } else {
                         unconfirmedText.setText(getResources().getString(R.string.txUnverifiedTx) + " " +
-                                ((GreenAddressApplication) getActivity().getApplication()).gaService.getSpvBlocksLeft());
+                                getGAService().getSpvBlocksLeft());
                     }
                 }
             }
 
-            final String btcUnit = (String) ((GreenAddressApplication) getActivity().getApplication()).gaService.getAppearanceValue("unit");
+            final String btcUnit = (String) getGAService().getAppearanceValue("unit");
             final Coin coin = Coin.valueOf(t.amount);
             final MonetaryFormat bitcoinFormat = CurrencyMapper.mapBtcUnitToFormat(btcUnit);
             bitcoinScale.setText(Html.fromHtml(CurrencyMapper.mapBtcUnitToPrefix(btcUnit)));
@@ -170,16 +168,16 @@ public class TransactionActivity extends ActionBarActivity implements Observer {
     @Override
     public void onResume() {
         super.onResume();
-        if (((GreenAddressApplication) getApplication()).gaService == null) {
+        if (getGAService() == null) {
             finish();
             return;
         }
-        ((GreenAddressApplication) getApplication()).getConnectionObservable().addObserver(this);
+        getGAApp().getConnectionObservable().addObserver(this);
     }
 
     @Override
     public void onPause() {
         super.onPause();
-        ((GreenAddressApplication) getApplication()).getConnectionObservable().deleteObserver(this);
+        getGAApp().getConnectionObservable().deleteObserver(this);
     }
 }

--- a/app/src/main/java/com/greenaddress/greenbits/ui/TwoFactorActivity.java
+++ b/app/src/main/java/com/greenaddress/greenbits/ui/TwoFactorActivity.java
@@ -1,7 +1,6 @@
 package com.greenaddress.greenbits.ui;
 
 import android.graphics.drawable.BitmapDrawable;
-import android.support.v7.app.ActionBarActivity;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -19,7 +18,6 @@ import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.zxing.WriterException;
 import com.greenaddress.greenbits.GaService;
-import com.greenaddress.greenbits.GreenAddressApplication;
 import com.greenaddress.greenbits.QrBitmap;
 
 import java.util.Formatter;
@@ -36,7 +34,7 @@ public class TwoFactorActivity extends ActionBarActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        final GaService gaService = ((GreenAddressApplication) getApplication()).gaService;
+        final GaService gaService = getGAService();
         if (gaService == null) {
             finish();
             return;
@@ -129,7 +127,7 @@ public class TwoFactorActivity extends ActionBarActivity {
     }
 
     private void showProvideDetails(final int stepNum, final int numSteps, final String proxyCode) {
-        final GaService gaService = ((GreenAddressApplication) getApplication()).gaService;
+        final GaService gaService = getGAService();
         setContentView(R.layout.activity_two_factor_3_provide_details);
         final Button continueButton = (Button) findViewById(R.id.continueButton);
         TextView prompt = (TextView) findViewById(R.id.prompt);
@@ -192,7 +190,7 @@ public class TwoFactorActivity extends ActionBarActivity {
         ProgressBar progressBar = (ProgressBar) findViewById(R.id.progressBar);
         progressBar.setProgress(stepNum);
         progressBar.setMax(numSteps);
-        final GaService gaService = ((GreenAddressApplication) getApplication()).gaService;
+        final GaService gaService = getGAService();
 
 
         final Button continueButton = (Button) findViewById(R.id.continueButton);
@@ -242,7 +240,7 @@ public class TwoFactorActivity extends ActionBarActivity {
         ProgressBar progressBar = (ProgressBar) findViewById(R.id.progressBar);
         progressBar.setProgress(stepNum);
         progressBar.setMax(numSteps);
-        final GaService gaService = ((GreenAddressApplication) getApplication()).gaService;
+        final GaService gaService = getGAService();
 
         String gauth_url = (String) gaService.getTwoFacConfig().get("gauth_url");
         try {
@@ -293,7 +291,7 @@ public class TwoFactorActivity extends ActionBarActivity {
         final EditText code = (EditText) findViewById(R.id.code);
         final TextView prompt = (TextView) findViewById(R.id.prompt);
         prompt.setText(new Formatter().format(prompt.getText().toString(), twoFacTypeName).toString());
-        final GaService gaService = ((GreenAddressApplication) getApplication()).gaService;
+        final GaService gaService = getGAService();
         ProgressBar progressBar = (ProgressBar) findViewById(R.id.progressBar);
         progressBar.setProgress(stepNum);
         progressBar.setMax(numSteps);


### PR DESCRIPTION
When sending funds on my phone the GreenBits app always crashed after submitting the transaction. It was annoying enough, so I tracked it down to [MainFragment:153](https://github.com/greenaddress/GreenBits/blob/2da72b1c2946c2a6f3486a3f3477eec18de7efa1/app/src/main/java/com/greenaddress/greenbits/ui/MainFragment.java#L153) where getActivity() returned null due to the fragment being in the detached state and crashed the whole app.

The (quick) fix is to cache the GreenAddressApplication reference in the GAFragment, such that when the transaction is processed by MainFragment it doesn't crash the app due to still being in the detached state.

I got somewhat carried away and refactored the whole usage pattern of `((GreenAddressApplication) getApplication())` to `getGAApp()` and `getGAService()` functions.

I did some basic testing and it seems my changes didn't break anything else, however, it would be great if someone else verifies that the app doesn't crash due to anything I did.