### PR TITLE
Fix display of blocks left when not connected to spv

### DIFF
--- a/app/src/main/java/com/greenaddress/greenbits/GaService.java
+++ b/app/src/main/java/com/greenaddress/greenbits/GaService.java
@@ -139,7 +139,7 @@ public class GaService extends Service {
     private String receivingId;
     private String country;
     private byte[] gaitPath;
-    private int spvBlocksLeft;
+    private int spvBlocksLeft = Integer.MAX_VALUE;
     private Map<?, ?> twoFacConfig;
     private GaObservable twoFacConfigObservable = new GaObservable();
     private String deviceId;

--- a/app/src/main/java/com/greenaddress/greenbits/ui/MainFragment.java
+++ b/app/src/main/java/com/greenaddress/greenbits/ui/MainFragment.java
@@ -307,8 +307,14 @@ public class MainFragment extends GAFragment implements Observer {
                         public void run() {
                             if (spvStatusDialog != null) {
                                 try {
-                                    spvStatusDialog.setContent(getResources().getString(R.string.unconfirmedBalanceText) + " " +
-                                            String.valueOf(getGAService().getSpvBlocksLeft()));
+                                    if(getGAService().getSpvBlocksLeft() != Integer.MAX_VALUE) {
+                                        spvStatusDialog.setContent(getResources().getString(R.string.unconfirmedBalanceText) + " " +
+                                                getGAService().getSpvBlocksLeft());
+                                    }
+                                    else{
+                                        spvStatusDialog.setContent(getResources().getString(R.string.unconfirmedBalanceText) + " " +
+                                                "Not yet connected to SPV!");
+                                    }
                                     handler.postDelayed(this, 2000);
                                 } catch (IllegalStateException e) {
                                     e.printStackTrace();

--- a/app/src/main/java/com/greenaddress/greenbits/ui/TabbedMainActivity.java
+++ b/app/src/main/java/com/greenaddress/greenbits/ui/TabbedMainActivity.java
@@ -460,26 +460,6 @@ public class TabbedMainActivity extends ActionBarActivity implements ActionBar.T
         }
     }
 
-    private Boolean exit = false;
-    @Override
-    public void onBackPressed() {
-        if (exit) {
-            finish(); // finish activity
-        } else {
-            Toast.makeText(this, "Press Back again to Exit.",
-                    Toast.LENGTH_SHORT).show();
-            exit = true;
-            new Handler().postDelayed(new Runnable() {
-                @Override
-                public void run() {
-                    exit = false;
-                }
-            }, 3 * 1000);
-
-        }
-
-    }
-
     @Override
     public void update(final Observable observable, final Object data) {
         if (getGAApp().getConnectionObservable().getIsForcedLoggedOut() || getGAApp().getConnectionObservable().getIsForcedTimeout()) {

--- a/app/src/main/java/com/greenaddress/greenbits/ui/TabbedMainActivity.java
+++ b/app/src/main/java/com/greenaddress/greenbits/ui/TabbedMainActivity.java
@@ -8,7 +8,6 @@ import android.nfc.NdefRecord;
 import android.nfc.NfcAdapter;
 import android.os.Build;
 import android.os.Bundle;
-import android.os.Handler;
 import android.os.Parcelable;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;

--- a/app/src/main/java/com/greenaddress/greenbits/ui/TabbedMainActivity.java
+++ b/app/src/main/java/com/greenaddress/greenbits/ui/TabbedMainActivity.java
@@ -8,6 +8,7 @@ import android.nfc.NdefRecord;
 import android.nfc.NfcAdapter;
 import android.os.Build;
 import android.os.Bundle;
+import android.os.Handler;
 import android.os.Parcelable;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;

--- a/app/src/main/java/com/greenaddress/greenbits/ui/TransactionActivity.java
+++ b/app/src/main/java/com/greenaddress/greenbits/ui/TransactionActivity.java
@@ -130,8 +130,14 @@ public class TransactionActivity extends ActionBarActivity implements Observer {
                     if (t.spvVerified) {
                         rootView.findViewById(R.id.txUnconfirmed).setVisibility(View.GONE);
                     } else {
-                        unconfirmedText.setText(getResources().getString(R.string.txUnverifiedTx) + " " +
-                                getGAService().getSpvBlocksLeft());
+                        if(getGAService().getSpvBlocksLeft() != Integer.MAX_VALUE) {
+                            unconfirmedText.setText(getResources().getString(R.string.txUnverifiedTx) + " " +
+                                    getGAService().getSpvBlocksLeft());
+                        }
+                        else{
+                            unconfirmedText.setText(getResources().getString(R.string.txUnverifiedTx) + " " +
+                                    "Not yet connected to SPV!");
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Previously displayed 0, now simply tells user that you are not yet connected.

It also instantiates the spvblocksleft value to Integer.MAX_VALUE for sanity purposes.