### PR TITLE
logging out kills the app for now

### DIFF
--- a/app/src/main/java/com/greenaddress/greenbits/ConnectivityObservable.java
+++ b/app/src/main/java/com/greenaddress/greenbits/ConnectivityObservable.java
@@ -124,6 +124,7 @@ public class ConnectivityObservable extends Observable {
                     service.disconnect(false);
                     setChanged();
                     notifyObservers();
+                    System.exit(0);
                     return null;
                 }
             }, timeout, TimeUnit.MINUTES);


### PR DESCRIPTION
Mirrors current behavior of double-back on mainscreen and exit. Unfortunately the activity itself isn't killed before the exit call, so if user clicks on the icon before the activity is killed by the OS, it pops up briefly and disappears. 