### PR TITLE
Create MnemonicCode.INSTANCE before creating Wallet instance.

### DIFF
--- a/app/src/main/java/com/greenaddress/greenbits/GaService.java
+++ b/app/src/main/java/com/greenaddress/greenbits/GaService.java
@@ -473,6 +473,12 @@ public class GaService extends Service {
         super.onCreate();
         uiHandler = new Handler();
 
+        try {
+            MnemonicCode.INSTANCE = new MnemonicCode(getAssets().open("bip39-wordlist.txt"), null);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
         this.background_color = 0; // transparent
         connectionObservable = ((GreenAddressApplication) getApplication()).getConnectionObservable();
 


### PR DESCRIPTION
Required for Android as normal instantiation of Wallet is assumed to fail.