### PR TITLE
Fix race condition that causes wallet to log out randomly after altim…

### DIFF
--- a/app/src/main/java/com/greenaddress/greenbits/ConnectivityObservable.java
+++ b/app/src/main/java/com/greenaddress/greenbits/ConnectivityObservable.java
@@ -53,6 +53,7 @@ public class ConnectivityObservable extends Observable {
         this.state = state;
         if (state == State.LOGGEDIN) {
             this.forcedLoggedout = false;
+            this.stopTimer();
             this.disconnectTimeout = null;
             this.forcedTimeoutout = false;
         }

--- a/app/src/main/java/com/greenaddress/greenbits/ConnectivityObservable.java
+++ b/app/src/main/java/com/greenaddress/greenbits/ConnectivityObservable.java
@@ -53,8 +53,6 @@ public class ConnectivityObservable extends Observable {
         this.state = state;
         if (state == State.LOGGEDIN) {
             this.forcedLoggedout = false;
-            this.stopTimer();
-            this.disconnectTimeout = null;
             this.forcedTimeoutout = false;
         }
         setChanged();


### PR DESCRIPTION
…eout period. Start timer was being called one PIN ends, followed by setState(from successful connection to GAit servers), then right after stopTimer was being called for TabbedMainActivity, only to find the timeout variable null.

{start/stop}Timer and setState still seems too race-prone. We simply remove the nullification of the timeout variable. 

This should get rid of issue where Tor SPV users get logged out 100% of the time after altimeout. 

