### PR TITLE
SPV button now enables/disables SPV dynamically

### DIFF
--- a/app/src/main/java/com/greenaddress/greenbits/GaService.java
+++ b/app/src/main/java/com/greenaddress/greenbits/GaService.java
@@ -114,6 +114,8 @@ public class GaService extends Service {
     private ListenableFuture<QrBitmap> latestQrBitmapMnemonics;
     private ListenableFuture<String> latestMnemonics;
     private final Object startSPVLock = new Object();
+    private int curBlock = 0;
+    private boolean spvWiFiDialogShown = false;
 
     private boolean reconnect = true, isSpvSyncing = false, startSpvAfterInit = false, syncStarted = false;
 
@@ -467,7 +469,7 @@ public class GaService extends Service {
     public void onCreate() {
         super.onCreate();
         uiHandler = new Handler();
-        
+
         try {
             MnemonicCode.INSTANCE = new MnemonicCode(getAssets().open("bip39-wordlist.txt"), null);
         } catch (IOException e) {
@@ -1485,5 +1487,21 @@ public class GaService extends Service {
 
     public PeerGroup getPeerGroup(){
         return this.peerGroup;
+    }
+    
+    public int getCurBlock(){
+        return curBlock;
+    }
+
+    public void setCurBlock(int newBlock){
+        curBlock = newBlock;
+    }
+
+    public boolean getSpvWiFiDialogShown(){
+        return spvWiFiDialogShown;
+    }
+
+    public void setSpvWiFiDialogShown(boolean shown){
+        spvWiFiDialogShown = shown;
     }
 }

--- a/app/src/main/java/com/greenaddress/greenbits/ui/MainFragment.java
+++ b/app/src/main/java/com/greenaddress/greenbits/ui/MainFragment.java
@@ -49,7 +49,7 @@ import javax.annotation.Nullable;
 public class MainFragment extends GAFragment implements Observer {
     public static final int P2SH_FORTIFIED_OUT = 10;
     Observer wiFiObserver = null;
-    boolean wiFiObserverRequired = false, spvWiFiDialogShown = false;
+    boolean wiFiObserverRequired = false;
     MaterialDialog spvStatusDialog = null;
     private View rootView;
     private List<Transaction> currentList;
@@ -457,6 +457,7 @@ public class MainFragment extends GAFragment implements Observer {
             public void onSuccess(@Nullable final Map<?, ?> result) {
                 final List resultList = (List) result.get("list");
                 final int curBlock = ((Number) result.get("cur_block")).intValue();
+                getGAService().setCurBlock(curBlock);
 
                 activity.runOnUiThread(new Runnable() {
                     @Override
@@ -540,14 +541,14 @@ public class MainFragment extends GAFragment implements Observer {
     }
 
     private void askUserForSpvNoWiFi() {
-        if (spvWiFiDialogShown) return;
+        if (getGAService().getSpvWiFiDialogShown()) return;
         if (!getActivity().getSharedPreferences(
                 "SPV",
                 getActivity().MODE_PRIVATE
         ).getBoolean("enabled", true)) {
             return;
         }
-        spvWiFiDialogShown = true;
+        getGAService().setSpvWiFiDialogShown(true);
         new MaterialDialog.Builder(getActivity())
                 .title(getResources().getString(R.string.spvNoWiFiTitle))
                 .content(getResources().getString(R.string.spvNoWiFiText))
@@ -561,6 +562,7 @@ public class MainFragment extends GAFragment implements Observer {
                 .callback(new MaterialDialog.ButtonCallback() {
                     @Override
                     public void onNegative(MaterialDialog materialDialog) {
+                        getGAService().setSpvWiFiDialogShown(false);
                         makeWiFiObserver();
                     }
 

--- a/app/src/main/java/com/greenaddress/greenbits/ui/SettingsActivity.java
+++ b/app/src/main/java/com/greenaddress/greenbits/ui/SettingsActivity.java
@@ -167,9 +167,9 @@ public class SettingsActivity extends PreferenceActivity implements Observer {
                     protected Object doInBackground(Object[] params) {
                         final Boolean nowEnabled = (Boolean) newValue;
 
-                        if(nowEnabled){
+                        if (nowEnabled) {
                             getGAService().setUpSPV();
-                            if(getGAService().getCurBlock() - getGAService().getSpvHeight() > 1000) {
+                            if (getGAService().getCurBlock() - getGAService().getSpvHeight() > 1000) {
                                 if (getGAApp().getConnectionObservable().isWiFiUp()) {
                                     getGAService().startSpvSync();
                                 } else {
@@ -181,7 +181,7 @@ public class SettingsActivity extends PreferenceActivity implements Observer {
                                         }
                                     });
                                 }
-                            }else{
+                            } else {
                                 runOnUiThread(new Runnable() {
                                     @Override
                                     public void run() {
@@ -191,8 +191,8 @@ public class SettingsActivity extends PreferenceActivity implements Observer {
 
                             }
 
-                        }else{
-                            if(getGAService().isPeerGroupRunning()) {
+                        } else {
+                            if (getGAService().isPeerGroupRunning()) {
                                 getGAService().stopSPVSync();
                             }
                             getGAService().tearDownSPV();
@@ -241,7 +241,7 @@ public class SettingsActivity extends PreferenceActivity implements Observer {
                     getGAService().tearDownSPV();
                     System.gc(); //May help save slightly lower heap size devices.
                     getGAService().setUpSPV();
-                    if(alreadySyncing){
+                    if (alreadySyncing) {
                         getGAService().startSpvSync();
                     }
                     return null;
@@ -277,7 +277,7 @@ public class SettingsActivity extends PreferenceActivity implements Observer {
                         trusted_peer.setSummary(newString);
                         new SPVAsync().execute();
                     }
-                    else{
+                    else {
                         new MaterialDialog.Builder(SettingsActivity.this)
                                 .title(getResources().getString(R.string.changingWarnOnionTitle))
                                 .content(getResources().getString(R.string.changingWarnOnionText))


### PR DESCRIPTION
If there is no Wifi and SPV is behind by more than 1000 blocks, user will be asked if they want to enable SPV sync anytime they turn it on, or as they load the app, unless they click "cancel". If user clicks "cancel" they will be prompted the next time they cycle the SPV sync button until they click "ok".