### PR TITLE
Take down SPV only in the case of intent to log out.

### DIFF
--- a/app/src/main/java/com/greenaddress/greenbits/GaService.java
+++ b/app/src/main/java/com/greenaddress/greenbits/GaService.java
@@ -516,9 +516,6 @@ public class GaService extends Service {
             public void onConnectionClosed(final int code) {
                 gaDeterministicKeys = null;
 
-                stopSPVSync();
-                tearDownSPV();
-
                 if (code == 4000) {
                     connectionObservable.setForcedLoggedOut();
                 }
@@ -982,6 +979,8 @@ public class GaService extends Service {
 
     public void disconnect(final boolean reconnect) {
         this.reconnect = reconnect;
+        stopSPVSync();
+        tearDownSPV();
         for (Long key : balanceObservables.keySet()) {
             balanceObservables.get(key).deleteObservers();
         }


### PR DESCRIPTION
This lets client re-connect to SPV after temporary loss of connection. 