### PR TITLE
Add watch only support (both setup and login)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -154,6 +154,7 @@
             android:label="@string/pref_header_proxy"/>
         <activity android:name=".FailHardActivity"/>
         <activity android:name=".AboutActivity"/>
+        <activity android:name=".WatchOnlyLoginActivity"/>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/greenaddress/greenapi/LoginData.java
+++ b/app/src/main/java/com/greenaddress/greenapi/LoginData.java
@@ -11,7 +11,7 @@ public class LoginData {
     private final static int EPOCH_START = 1393628400;
 
     public final String exchange;
-    public final String currency;
+    public String currency;
     public final Map<String, Object> userConfig;
     public Map<String, Object> feeEstimates;
     public final ArrayList subAccounts;

--- a/app/src/main/java/com/greenaddress/greenapi/WalletClient.java
+++ b/app/src/main/java/com/greenaddress/greenapi/WalletClient.java
@@ -65,6 +65,8 @@ public class WalletClient {
     private SocketAddress mProxy = null;
     private LoginData mLoginData;
     private ISigningWallet mHDParent;
+    private String mWatchOnlyUsername = null;
+    private String mWatchOnlyPassword = null;
     private String mMnemonics = null;
     private final OkHttpClient httpClient = new OkHttpClient();
 
@@ -287,6 +289,7 @@ public class WalletClient {
         // FIXME: Server should handle logout without having to disconnect
         mLoginData = null;
         mMnemonics = null;
+        mWatchOnlyUsername = null;
 
         mHDParent = null;
 
@@ -501,6 +504,51 @@ public class WalletClient {
         return login(signingWallet, deviceId);
     }
 
+    private LoginData watchOnlyLoginImpl(final String username, final String password) throws Exception {
+        final Map<String, String> credentials = new HashMap<>(2);
+        credentials.put("username", username);
+        credentials.put("password", password);
+        final Object ret = syncCall("login.watch_only",  Object.class, "custom", credentials, false);
+        final Map<?, ?> json;
+        json = new MappingJsonFactory().getCodec().readValue((String)ret, Map.class);
+        mLoginData = new LoginData(json);
+        subscribeToWallet();  // requires receivingId to be set
+        mHDParent = null;
+        mWatchOnlyUsername = username;
+        mWatchOnlyPassword = password;
+        return mLoginData;
+    }
+
+    public void disableWatchOnly() throws Exception {
+        syncCall("addressbook.disable_sync",  Void.class, "custom");
+        mWatchOnlyPassword = null;
+        mWatchOnlyUsername = null;
+    }
+
+    public boolean isWatchOnly() {
+        return mWatchOnlyUsername != null && !mWatchOnlyUsername.isEmpty() && mWatchOnlyPassword != null && !mWatchOnlyPassword.isEmpty();
+    }
+
+    public boolean registerWatchOnly(final String username, final String password) throws Exception {
+
+        final boolean res = syncCall("addressbook.sync_custom", Boolean.class, username , password);
+        if (res)
+            mWatchOnlyUsername = username;
+        return res;
+    }
+
+    public String getWatchOnlyUsername() throws Exception {
+        if (mWatchOnlyUsername == null) {
+            final Map<?, ?> sync_status = syncCall("addressbook.get_sync_status", Map.class);
+            mWatchOnlyUsername = (String) sync_status.get("username");
+        }
+        return mWatchOnlyUsername;
+    }
+
+    public String getWatchOnlyPassword() {
+        return mWatchOnlyPassword;
+    }
+
     private LoginData loginImpl(final ISigningWallet signingWallet, final String deviceId) throws Exception, LoginFailed {
 
         // FIXME: Unify this RPC call, this is ugly
@@ -524,12 +572,27 @@ public class WalletClient {
         mLoginData = new LoginData((Map) ret);
         subscribeToWallet();  // requires receivingId to be set
         mHDParent = signingWallet;
+        mWatchOnlyUsername = null;
+        mWatchOnlyPassword = null;
 
         if (mLoginData.rbf && getUserConfig("replace_by_fee") == null) {
             // Enable rbf if server supports it and not disabled by user explicitly
             setUserConfig("replace_by_fee", Boolean.TRUE, false);
         }
         return mLoginData;
+    }
+
+    public ListenableFuture<LoginData> watchOnlylogin(final String username, final String password) {
+        return mExecutor.submit(new Callable<LoginData>() {
+            @Override
+            public LoginData call() {
+                try {
+                    return watchOnlyLoginImpl(username, password);
+                } catch (final Throwable t) {
+                    throw Throwables.propagate(t);
+                }
+            }
+        });
     }
 
     public ListenableFuture<LoginData> login(final ISigningWallet signingWallet, final String deviceId) {

--- a/app/src/main/java/com/greenaddress/greenbits/ui/CB.java
+++ b/app/src/main/java/com/greenaddress/greenbits/ui/CB.java
@@ -47,7 +47,7 @@ public final class CB {
 
        @Override
        final public void onFailure(final Throwable t) {
-           GaActivity.toast(mActivity, t, mEnabler);
+           UI.toast(mActivity, t, mEnabler);
        }
     }
 

--- a/app/src/main/java/com/greenaddress/greenbits/ui/FailHardActivity.java
+++ b/app/src/main/java/com/greenaddress/greenbits/ui/FailHardActivity.java
@@ -23,7 +23,7 @@ public class FailHardActivity extends AppCompatActivity {
         final Intent i = getIntent();
         Log.e(TAG, i.getStringExtra("errorTitle") + ":" + i.getStringExtra("errorContent"));
 
-        GaActivity.popup(this, i.getStringExtra("errorTitle"))
+        UI.popup(this, i.getStringExtra("errorTitle"))
                   .content(i.getStringExtra("errorContent"))
                   .onPositive(new MaterialDialog.SingleButtonCallback() {
                     @Override

--- a/app/src/main/java/com/greenaddress/greenbits/ui/FirstScreenActivity.java
+++ b/app/src/main/java/com/greenaddress/greenbits/ui/FirstScreenActivity.java
@@ -260,8 +260,7 @@ public class FirstScreenActivity extends GaActivity {
 
     @Override
     public boolean onCreateOptionsMenu(final Menu menu) {
-        // Disable proxy until fully working
-        // getMenuInflater().inflate(R.menu.proxy_menu, menu);
+        getMenuInflater().inflate(R.menu.preauth_menu, menu);
         return true;
     }
 
@@ -274,12 +273,18 @@ public class FirstScreenActivity extends GaActivity {
         // Handle action bar item clicks here. The action bar will
         // automatically handle clicks on the Home/Up button, so long
         // as you specify a parent activity in AndroidManifest.xml.
-        final int id = item.getItemId();
-        if (id == R.id.proxy_preferences) {
-            startNewActivity(ProxySettingsActivity.class);
-            return true;
+
+        switch (item.getItemId()) {
+            case R.id.watchonly_preference:
+                startActivity(new Intent(FirstScreenActivity.this, WatchOnlyLoginActivity.class));
+                return true;
+            case R.id.proxy_preferences:
+                startActivity(new Intent(FirstScreenActivity.this, ProxySettingsActivity.class));
+                return true;
+            case R.id.action_settings:
+                return true;
         }
-        return id == R.id.action_settings || super.onOptionsItemSelected(item);
+        return super.onOptionsItemSelected(item);
     }
 
     @Override

--- a/app/src/main/java/com/greenaddress/greenbits/ui/FirstScreenActivity.java
+++ b/app/src/main/java/com/greenaddress/greenbits/ui/FirstScreenActivity.java
@@ -109,7 +109,7 @@ public class FirstScreenActivity extends GaActivity {
                         FirstScreenActivity.this.runOnUiThread(new Runnable() {
                             @Override
                             public void run() {
-                                popup(FirstScreenActivity.this, "Ledger Wallet Trustlet")
+                                UI.popup(FirstScreenActivity.this, "Ledger Wallet Trustlet")
                                         .content("Ledger Wallet Trustlet is available - do you want to use it to register ?")
                                         .onPositive(new MaterialDialog.SingleButtonCallback() {
                                             @Override

--- a/app/src/main/java/com/greenaddress/greenbits/ui/GaActivity.java
+++ b/app/src/main/java/com/greenaddress/greenbits/ui/GaActivity.java
@@ -1,6 +1,5 @@
 package com.greenaddress.greenbits.ui;
 
-import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
@@ -8,17 +7,12 @@ import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
-import android.widget.Button;
 import android.widget.Toast;
 
-import com.afollestad.materialdialogs.MaterialDialog;
-import com.afollestad.materialdialogs.Theme;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.greenaddress.greenbits.GaService;
 import com.greenaddress.greenbits.GreenAddressApplication;
-
-import java.util.List;
 
 /**
  * Base class for activities within the application.
@@ -29,7 +23,6 @@ import java.util.List;
 public abstract class GaActivity extends AppCompatActivity {
 
     private static final String TAG = GaActivity.class.getSimpleName();
-    private static final int INVALID_RESOURCE_ID = 0;
 
     // Both of these variables are only assigned in the UI thread.
     // mService is available to all derived classes as soon as
@@ -47,7 +40,7 @@ public abstract class GaActivity extends AppCompatActivity {
         Log.d(TAG, "onCreate -> " + this.getClass().getSimpleName());
         super.onCreate(savedInstanceState);
         final int viewId = getMainViewId();
-        if (viewId != INVALID_RESOURCE_ID)
+        if (viewId != UI.INVALID_RESOURCE_ID)
             setContentView(viewId);
 
         // Call onCreateWithService() on the GUI thread once our service
@@ -104,7 +97,7 @@ public abstract class GaActivity extends AppCompatActivity {
     }
 
     /** Override to provide the main view id */
-    protected int getMainViewId() { return INVALID_RESOURCE_ID; }
+    protected int getMainViewId() { return UI.INVALID_RESOURCE_ID; }
 
     /** Override to provide onCreate/onResume/onPause processing.
       * When called, our service is guaranteed to be available. */
@@ -151,97 +144,9 @@ public abstract class GaActivity extends AppCompatActivity {
         });
     }
 
-    public static void toastImpl(final Activity activity, final int id, final int len) {
-        activity.runOnUiThread(new Runnable() {
-            public void run() { Toast.makeText(activity, id, len).show(); }
-        });
-    }
-
-    public static void toastImpl(final Activity activity, final String s, final int len) {
-        activity.runOnUiThread(new Runnable() {
-            public void run() { Toast.makeText(activity, s, len).show(); }
-        });
-    }
-
-    public static void toast(final Activity activity, final Throwable t, final Button reenable) {
-        activity.runOnUiThread(new Runnable() {
-            public void run() {
-                if (reenable != null)
-                    reenable.setEnabled(true);
-                t.printStackTrace();
-                Toast.makeText(activity, t.getMessage(), Toast.LENGTH_LONG).show();
-            }
-        });
-    }
-    public void toast(final Throwable t) { toast(this, t, null); }
-    public void toast(final int id) { toastImpl(this, id, Toast.LENGTH_LONG); }
-    public void toast(final String s) { toastImpl(this, s, Toast.LENGTH_LONG); }
-    public void shortToast(final int id) { toastImpl(this, id, Toast.LENGTH_SHORT); }
-    public void shortToast(final String s) { toastImpl(this, s, Toast.LENGTH_SHORT); }
-
-    public static MaterialDialog.Builder popup(final Activity a, final String title, final int pos, final int neg) {
-        final MaterialDialog.Builder b;
-        b = new MaterialDialog.Builder(a)
-                              .title(title)
-                              .titleColorRes(R.color.white)
-                              .positiveColorRes(R.color.accent)
-                              .negativeColorRes(R.color.accent)
-                              .contentColorRes(R.color.white)
-                              .theme(Theme.DARK);
-       if (pos != INVALID_RESOURCE_ID)
-           b.positiveText(pos);
-       if (neg != INVALID_RESOURCE_ID)
-           return b.negativeText(neg);
-       return b;
-    }
-
-    public static MaterialDialog.Builder popup(final Activity a, final int title, final int pos, final int neg) {
-        return popup(a, a.getString(title), pos, neg);
-    }
-
-    public static MaterialDialog.Builder popup(final Activity a, final String title, final int pos) {
-        return popup(a, title, pos, INVALID_RESOURCE_ID);
-    }
-
-    public static MaterialDialog.Builder popup(final Activity a, final int title, final int pos) {
-        return popup(a, title, pos, INVALID_RESOURCE_ID);
-    }
-
-    public static MaterialDialog.Builder popup(final Activity a, final String title) {
-        return popup(a, title, android.R.string.ok, android.R.string.cancel);
-    }
-
-    public static MaterialDialog.Builder popup(final Activity a, final int title) {
-        return popup(a, title, android.R.string.ok, android.R.string.cancel);
-    }
-
-    public static MaterialDialog popupTwoFactorChoice(final Activity a, final GaService service,
-                                                      final boolean skip, final CB.Runnable1T<String> callback) {
-        final List<String> names = service.getEnabledTwoFacNames(false);
-
-        if (skip || names.size() <= 1) {
-           // Caller elected to skip, or no choices are available: don't prompt
-           a.runOnUiThread(new Runnable() {
-               @Override
-               public void run() {
-                   callback.run(names.isEmpty() ? null : service.getEnabledTwoFacNames(true).get(0));
-               }
-           });
-           return null;
-        }
-
-        // Return a pop up dialog to let the user choose.
-        String[] namesArray = new String[names.size()];
-        namesArray = names.toArray(namesArray);
-        return popup(a, R.string.twoFactorChoicesTitle, R.string.choose, R.string.cancel)
-                   .items(namesArray)
-                   .itemsCallbackSingleChoice(0, new MaterialDialog.ListCallbackSingleChoice() {
-                       @Override
-                       public boolean onSelection(MaterialDialog dlg, View v, int which, CharSequence text) {
-                           final List<String> systemNames = service.getEnabledTwoFacNames(true);
-                           callback.run(systemNames.get(which));
-                           return true;
-                       }
-                   }).build();
-    }
+    public void toast(final Throwable t) { UI.toast(this, t, null); }
+    public void toast(final int id) { UI.toast(this, id, Toast.LENGTH_LONG); }
+    public void toast(final String s) { UI.toast(this, s, Toast.LENGTH_LONG); }
+    public void shortToast(final int id) { UI.toast(this, id, Toast.LENGTH_SHORT); }
+    public void shortToast(final String s) { UI.toast(this, s, Toast.LENGTH_SHORT); }
 }

--- a/app/src/main/java/com/greenaddress/greenbits/ui/MainFragment.java
+++ b/app/src/main/java/com/greenaddress/greenbits/ui/MainFragment.java
@@ -149,7 +149,7 @@ public class MainFragment extends SubaccountFragment {
             public void onClick(final View v) {
                 if (mUnconfirmedDialog == null && balanceQuestionMark.getVisibility() == View.VISIBLE) {
                     // Question mark is visible and dialog not shown, so show it
-                    mUnconfirmedDialog = GaActivity.popup(getActivity(), R.string.unconfirmedBalanceTitle, 0)
+                    mUnconfirmedDialog = UI.popup(getActivity(), R.string.unconfirmedBalanceTitle, 0)
                             .content(R.string.unconfirmedBalanceText)
                             .cancelListener(new DialogInterface.OnCancelListener() {
                                 @Override

--- a/app/src/main/java/com/greenaddress/greenbits/ui/MnemonicActivity.java
+++ b/app/src/main/java/com/greenaddress/greenbits/ui/MnemonicActivity.java
@@ -197,7 +197,7 @@ public class MnemonicActivity extends GaActivity {
                 final View inflatedLayout = getLayoutInflater().inflate(R.layout.dialog_passphrase, null, false);
                 final EditText passphraseValue = (EditText) inflatedLayout.findViewById(R.id.passphraseValue);
                 passphraseValue.requestFocus();
-                final MaterialDialog dialog = popup(MnemonicActivity.this, "Encryption passphrase")
+                final MaterialDialog dialog = UI.popup(MnemonicActivity.this, "Encryption passphrase")
                         .customView(inflatedLayout, true)
                         .onPositive(new MaterialDialog.SingleButtonCallback() {
                             @Override

--- a/app/src/main/java/com/greenaddress/greenbits/ui/PinActivity.java
+++ b/app/src/main/java/com/greenaddress/greenbits/ui/PinActivity.java
@@ -9,11 +9,9 @@ import android.os.Build;
 import android.os.Bundle;
 import android.security.keystore.KeyProperties;
 import android.util.Base64;
-import android.view.KeyEvent;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
-import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.EditText;
 import android.widget.TextView;
@@ -176,25 +174,12 @@ public class PinActivity extends GaActivity implements Observer {
         if (androidLogin == null) {
 
             mPinText.setOnEditorActionListener(
-                    new EditText.OnEditorActionListener() {
+                    UI.getListenerRunOnEnter(new Runnable() {
                         @Override
-                        public boolean onEditorAction(final TextView v, final int actionId, final KeyEvent event) {
-                            if (actionId == EditorInfo.IME_ACTION_SEARCH ||
-                                    actionId == EditorInfo.IME_ACTION_DONE ||
-                                    (event != null && event.getAction() == KeyEvent.ACTION_DOWN) &&
-                                            event.getKeyCode() == KeyEvent.KEYCODE_ENTER) {
-                                if (event == null || !event.isShiftPressed()) {
-                                    // the user is done typing.
-                                    if (!mPinText.getText().toString().isEmpty()) {
-                                        login();
-                                        return true; // consume.
-                                    }
-                                }
-                            }
-                            return false; // pass on to other listeners.
+                        public void run() {
+                            login();
                         }
-                    }
-            );
+                    }));
 
             mPinLoginButton.setOnClickListener(new View.OnClickListener() {
                 @Override

--- a/app/src/main/java/com/greenaddress/greenbits/ui/PinActivity.java
+++ b/app/src/main/java/com/greenaddress/greenbits/ui/PinActivity.java
@@ -312,10 +312,7 @@ public class PinActivity extends GaActivity implements Observer {
     @Override
     public boolean onCreateOptionsMenu(final Menu menu) {
         getMenuInflater().inflate(R.menu.common_menu, menu);
-
-        // disable proxy until fully working
-        // getMenuInflater().inflate(R.menu.proxy_menu, menu);
-
+        getMenuInflater().inflate(R.menu.preauth_menu, menu);
         mMenu = menu;
         return true;
     }
@@ -327,6 +324,9 @@ public class PinActivity extends GaActivity implements Observer {
                 return true;
             case R.id.proxy_preferences:
                 startActivity(new Intent(this, ProxySettingsActivity.class));
+                return true;
+            case R.id.watchonly_preference:
+                startActivity(new Intent(PinActivity.this, WatchOnlyLoginActivity.class));
                 return true;
         }
         return super.onOptionsItemSelected(item);

--- a/app/src/main/java/com/greenaddress/greenbits/ui/PinSaveActivity.java
+++ b/app/src/main/java/com/greenaddress/greenbits/ui/PinSaveActivity.java
@@ -5,17 +5,14 @@ import android.content.Context;
 import android.content.Intent;
 import android.os.Build;
 import android.os.Bundle;
-import android.view.KeyEvent;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
-import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.Button;
 import android.widget.CheckBox;
 import android.widget.CompoundButton;
 import android.widget.EditText;
-import android.widget.TextView;
 
 import com.dd.CircularProgressButton;
 import com.google.common.util.concurrent.FutureCallback;
@@ -126,23 +123,12 @@ public class PinSaveActivity extends GaActivity {
         }
 
         mPinText.setOnEditorActionListener(
-                new EditText.OnEditorActionListener() {
+                UI.getListenerRunOnEnter(new Runnable() {
                     @Override
-                    public boolean onEditorAction(final TextView v, final int actionId, final KeyEvent event) {
-                        if (actionId == EditorInfo.IME_ACTION_SEARCH ||
-                                actionId == EditorInfo.IME_ACTION_DONE ||
-                                (event != null && event.getAction() == KeyEvent.ACTION_DOWN) &&
-                                        event.getKeyCode() == KeyEvent.KEYCODE_ENTER) {
-                            if (event == null || !event.isShiftPressed()) {
-                                // the user is done typing.
-                                setPin(mPinText.getText().toString());
-                                return true; // consume.
-                            }
-                        }
-                        return false; // pass on to other listeners.
+                    public void run() {
+                        setPin(mPinText.getText().toString());
                     }
-                }
-        );
+                }));
 
         mSaveButton = (CircularProgressButton) mapClick(R.id.pinSaveButton, new View.OnClickListener() {
             public void onClick(final View view) {

--- a/app/src/main/java/com/greenaddress/greenbits/ui/RequestLoginActivity.java
+++ b/app/src/main/java/com/greenaddress/greenbits/ui/RequestLoginActivity.java
@@ -9,11 +9,9 @@ import android.nfc.NfcAdapter;
 import android.nfc.Tag;
 import android.os.Bundle;
 import android.util.Log;
-import android.view.KeyEvent;
 import android.view.View;
 import android.view.Window;
 import android.view.WindowManager;
-import android.view.inputmethod.EditorInfo;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.ProgressBar;
@@ -106,7 +104,7 @@ public class RequestLoginActivity extends GaActivity implements OnDiscoveredTagL
                                         }
                                     });
                                 }
-                                popup(RequestLoginActivity.this, "Hardware Wallet PIN")
+                                UI.popup(RequestLoginActivity.this, "Hardware Wallet PIN")
                                     .customView(inflatedLayout, true)
                                     .onPositive(new MaterialDialog.SingleButtonCallback() {
                                         @Override
@@ -132,7 +130,7 @@ public class RequestLoginActivity extends GaActivity implements OnDiscoveredTagL
                             public void run() {
                                 final View inflatedLayout = getLayoutInflater().inflate(R.layout.dialog_trezor_passphrase, null, false);
                                 final EditText passphraseValue = (EditText) inflatedLayout.findViewById(R.id.trezorPassphraseValue);
-                                popup(RequestLoginActivity.this, "Hardware Wallet passphrase")
+                                UI.popup(RequestLoginActivity.this, "Hardware Wallet passphrase")
                                     .customView(inflatedLayout, true)
                                     .onPositive(new MaterialDialog.SingleButtonCallback() {
                                         @Override
@@ -232,7 +230,7 @@ public class RequestLoginActivity extends GaActivity implements OnDiscoveredTagL
             public void run() {
                 final View inflatedLayout = getLayoutInflater().inflate(R.layout.dialog_btchip_pin, null, false);
                 final EditText pinValue = (EditText) inflatedLayout.findViewById(R.id.btchipPINValue);
-                btchipDialog = popup(RequestLoginActivity.this, "BTChip PIN")
+                btchipDialog = UI.popup(RequestLoginActivity.this, "BTChip PIN")
                         .customView(inflatedLayout, true)
                         .onPositive(new MaterialDialog.SingleButtonCallback() {
                             @Override
@@ -256,25 +254,15 @@ public class RequestLoginActivity extends GaActivity implements OnDiscoveredTagL
                 btchipWindow.clearFlags(WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE | WindowManager.LayoutParams.FLAG_ALT_FOCUSABLE_IM);
                 btchipWindow.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_VISIBLE);
                 pinValue.setOnEditorActionListener(
-                        new EditText.OnEditorActionListener() {
+                        UI.getListenerRunOnEnter(new Runnable() {
                             @Override
-                            public boolean onEditorAction(final TextView v, final int actionId, final KeyEvent event) {
-                                if (actionId == EditorInfo.IME_ACTION_SEARCH ||
-                                        actionId == EditorInfo.IME_ACTION_DONE ||
-                                        (event != null && event.getAction() == KeyEvent.ACTION_DOWN) &&
-                                                event.getKeyCode() == KeyEvent.KEYCODE_ENTER) {
-                                    if (event == null || !event.isShiftPressed()) {
-                                        // the user is done typing.
-                                        final ProgressBar prog = (ProgressBar) findViewById(R.id.signingLogin);
-                                        prog.setVisibility(View.VISIBLE);
-                                        btchipDialog.hide();
-                                        pinFuture.set(pinValue.getText().toString());
-                                        return true; // consume.
-                                    }
-                                }
-                                return false; // pass on to other listeners.
+                            public void run() {
+                                final ProgressBar prog = (ProgressBar) findViewById(R.id.signingLogin);
+                                prog.setVisibility(View.VISIBLE);
+                                btchipDialog.hide();
+                                pinFuture.set(pinValue.getText().toString());
                             }
-                        }
+                        })
                 );
                 btchipDialog.show();
             }

--- a/app/src/main/java/com/greenaddress/greenbits/ui/SendFragment.java
+++ b/app/src/main/java/com/greenaddress/greenbits/ui/SendFragment.java
@@ -126,7 +126,7 @@ public class SendFragment extends SubaccountFragment {
             }
         }
 
-        mSummary = GaActivity.popup(getActivity(), R.string.newTxTitle, R.string.send, R.string.cancel)
+        mSummary = UI.popup(getActivity(), R.string.newTxTitle, R.string.send, R.string.cancel)
                 .customView(inflatedLayout, true)
                 .onPositive(new MaterialDialog.SingleButtonCallback() {
                     @Override
@@ -398,7 +398,7 @@ public class SendFragment extends SubaccountFragment {
                                                             }
                                                             final boolean skipChoice = !ptx.requires_2factor ||
                                                                                         twoFacConfig == null || !((Boolean) twoFacConfig.get("any"));
-                                                            mTwoFactor = GaActivity.popupTwoFactorChoice(gaActivity, service, skipChoice,
+                                                            mTwoFactor = UI.popupTwoFactorChoice(gaActivity, service, skipChoice,
                                                                                                          new CB.Runnable1T<String>() {
                                                                 @Override
                                                                 public void run(final String method) {

--- a/app/src/main/java/com/greenaddress/greenbits/ui/TabbedMainActivity.java
+++ b/app/src/main/java/com/greenaddress/greenbits/ui/TabbedMainActivity.java
@@ -349,7 +349,7 @@ public class TabbedMainActivity extends GaActivity implements Observer {
 
                         addressText.setText(String.format("%s\n%s\n%s", address.substring(0, 12), address.substring(12, 24), address.substring(24)));
 
-                        popup(caller, R.string.sweepAddressTitle, R.string.sweep, R.string.cancel)
+                        UI.popup(caller, R.string.sweepAddressTitle, R.string.sweep, R.string.cancel)
                             .customView(inflatedLayout, true)
                             .onPositive(new MaterialDialog.SingleButtonCallback() {
                                 Transaction tx;

--- a/app/src/main/java/com/greenaddress/greenbits/ui/TabbedMainActivity.java
+++ b/app/src/main/java/com/greenaddress/greenbits/ui/TabbedMainActivity.java
@@ -424,7 +424,10 @@ public class TabbedMainActivity extends GaActivity implements Observer {
     @Override
     public boolean onCreateOptionsMenu(final Menu menu) {
         // Inflate the menu; this adds items to the action bar if it is present.
-        getMenuInflater().inflate(R.menu.main, menu);
+        if (mService.isWatchOnly())
+            getMenuInflater().inflate(R.menu.watchonly, menu);
+        else
+            getMenuInflater().inflate(R.menu.main, menu);
         mMenu = menu;
         return true;
     }
@@ -530,7 +533,8 @@ public class TabbedMainActivity extends GaActivity implements Observer {
 
         @Override
         public int getCount() {
-            // Show 3 total pages.
+            if (mService.isWatchOnly())
+                return 2;
             return 3;
         }
 

--- a/app/src/main/java/com/greenaddress/greenbits/ui/TransactionActivity.java
+++ b/app/src/main/java/com/greenaddress/greenbits/ui/TransactionActivity.java
@@ -119,7 +119,7 @@ public class TransactionActivity extends GaActivity {
 
                     final String stripped = domain.startsWith("www.") ? domain.substring(4) : domain;
 
-                    popup(getActivity(), R.string.warning, R.string.continueText, R.string.cancel)
+                    UI.popup(getActivity(), R.string.warning, R.string.continueText, R.string.cancel)
                         .content(getString(R.string.view_block_explorer, stripped))
                         .onPositive(new MaterialDialog.SingleButtonCallback() {
                             @Override
@@ -692,7 +692,7 @@ public class TransactionActivity extends GaActivity {
                                 @Override
                                 public void run() {
                                     final boolean skipChoice = false;
-                                    mTwoFactor = GaActivity.popupTwoFactorChoice(gaActivity, service, skipChoice,
+                                    mTwoFactor = UI.popupTwoFactorChoice(gaActivity, service, skipChoice,
                                                                                  new CB.Runnable1T<String>() {
                                         @Override
                                         public void run(final String method) {
@@ -764,7 +764,7 @@ public class TransactionActivity extends GaActivity {
                 }
             }
 
-            mSummary = popup(getActivity(), R.string.feeIncreaseTitle, R.string.send, R.string.cancel)
+            mSummary = UI.popup(getActivity(), R.string.feeIncreaseTitle, R.string.send, R.string.cancel)
                     .customView(inflatedLayout, true)
                     .onPositive(new MaterialDialog.SingleButtonCallback() {
                         @Override

--- a/app/src/main/java/com/greenaddress/greenbits/ui/UI.java
+++ b/app/src/main/java/com/greenaddress/greenbits/ui/UI.java
@@ -1,0 +1,132 @@
+package com.greenaddress.greenbits.ui;
+
+import android.app.Activity;
+import android.view.KeyEvent;
+import android.view.View;
+import android.view.inputmethod.EditorInfo;
+import android.widget.Button;
+import android.widget.EditText;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import com.afollestad.materialdialogs.MaterialDialog;
+import com.afollestad.materialdialogs.Theme;
+import com.greenaddress.greenbits.GaService;
+
+import java.util.List;
+
+public abstract class UI {
+    public static final int INVALID_RESOURCE_ID = 0;
+
+    public static TextView.OnEditorActionListener getListenerRunOnEnter(final Runnable r) {
+        return new EditText.OnEditorActionListener() {
+            @Override
+            public boolean onEditorAction(final TextView v, final int actionId, final KeyEvent event) {
+                if (actionId == EditorInfo.IME_ACTION_SEARCH ||
+                        actionId == EditorInfo.IME_ACTION_DONE ||
+                        (event != null && event.getAction() == KeyEvent.ACTION_DOWN) &&
+                                event.getKeyCode() == KeyEvent.KEYCODE_ENTER) {
+                    if (event == null || !event.isShiftPressed()) {
+                        // the user is done typing.
+                        r.run();
+                        return true; // consume.
+                    }
+                }
+                return false; // pass on to other listeners.
+            }
+        };
+    }
+
+    public static MaterialDialog.Builder popup(final Activity a, final String title, final int pos, final int neg) {
+        final MaterialDialog.Builder b;
+        b = new MaterialDialog.Builder(a)
+                .title(title)
+                .titleColorRes(R.color.white)
+                .positiveColorRes(R.color.accent)
+                .negativeColorRes(R.color.accent)
+                .contentColorRes(R.color.white)
+                .theme(Theme.DARK);
+        if (pos != INVALID_RESOURCE_ID)
+            b.positiveText(pos);
+        if (neg != INVALID_RESOURCE_ID)
+            return b.negativeText(neg);
+        return b;
+    }
+
+    public static MaterialDialog.Builder popup(final Activity a, final int title, final int pos, final int neg) {
+        return popup(a, a.getString(title), pos, neg);
+    }
+
+    public static MaterialDialog.Builder popup(final Activity a, final String title, final int pos) {
+        return popup(a, title, pos, INVALID_RESOURCE_ID);
+    }
+
+    public static MaterialDialog.Builder popup(final Activity a, final int title, final int pos) {
+        return popup(a, title, pos, INVALID_RESOURCE_ID);
+    }
+
+    public static MaterialDialog.Builder popup(final Activity a, final String title) {
+        return popup(a, title, android.R.string.ok, android.R.string.cancel);
+    }
+
+    public static MaterialDialog.Builder popup(final Activity a, final int title) {
+        return popup(a, title, android.R.string.ok, android.R.string.cancel);
+    }
+
+    public static MaterialDialog popupTwoFactorChoice(final Activity a, final GaService service,
+                                                      final boolean skip, final CB.Runnable1T<String> callback) {
+        final List<String> names = service.getEnabledTwoFacNames(false);
+
+        if (skip || names.size() <= 1) {
+            // Caller elected to skip, or no choices are available: don't prompt
+            a.runOnUiThread(new Runnable() {
+                @Override
+                public void run() {
+                    callback.run(names.isEmpty() ? null : service.getEnabledTwoFacNames(true).get(0));
+                }
+            });
+            return null;
+        }
+
+        // Return a pop up dialog to let the user choose.
+        String[] namesArray = new String[names.size()];
+        namesArray = names.toArray(namesArray);
+        return popup(a, R.string.twoFactorChoicesTitle, R.string.choose, R.string.cancel)
+                .items(namesArray)
+                .itemsCallbackSingleChoice(0, new MaterialDialog.ListCallbackSingleChoice() {
+                    @Override
+                    public boolean onSelection(MaterialDialog dlg, View v, int which, CharSequence text) {
+                        final List<String> systemNames = service.getEnabledTwoFacNames(true);
+                        callback.run(systemNames.get(which));
+                        return true;
+                    }
+                }).build();
+    }
+
+    public static void toast(final Activity activity, final int id, final int len) {
+        activity.runOnUiThread(new Runnable() {
+            public void run() {
+                Toast.makeText(activity, id, len).show();
+            }
+        });
+    }
+
+    public static void toast(final Activity activity, final String s, final int len) {
+        activity.runOnUiThread(new Runnable() {
+            public void run() {
+                Toast.makeText(activity, s, len).show();
+            }
+        });
+    }
+
+    public static void toast(final Activity activity, final Throwable t, final Button reenable) {
+        activity.runOnUiThread(new Runnable() {
+            public void run() {
+                if (reenable != null)
+                    reenable.setEnabled(true);
+                t.printStackTrace();
+                Toast.makeText(activity, t.getMessage(), Toast.LENGTH_LONG).show();
+            }
+        });
+    }
+}

--- a/app/src/main/java/com/greenaddress/greenbits/ui/WatchOnlyLoginActivity.java
+++ b/app/src/main/java/com/greenaddress/greenbits/ui/WatchOnlyLoginActivity.java
@@ -2,11 +2,8 @@ package com.greenaddress.greenbits.ui;
 
 import android.content.Intent;
 import android.os.Bundle;
-import android.view.KeyEvent;
 import android.view.View;
-import android.view.inputmethod.EditorInfo;
 import android.widget.EditText;
-import android.widget.TextView;
 
 import com.dd.CircularProgressButton;
 import com.google.common.util.concurrent.FutureCallback;
@@ -40,23 +37,12 @@ public class WatchOnlyLoginActivity extends GaActivity {
         });
 
         mPasswordText.setOnEditorActionListener(
-                new EditText.OnEditorActionListener() {
+                UI.getListenerRunOnEnter(new Runnable() {
                     @Override
-                    public boolean onEditorAction(final TextView v, final int actionId, final KeyEvent event) {
-                        if (actionId == EditorInfo.IME_ACTION_SEARCH ||
-                                actionId == EditorInfo.IME_ACTION_DONE ||
-                                (event != null && event.getAction() == KeyEvent.ACTION_DOWN) &&
-                                        event.getKeyCode() == KeyEvent.KEYCODE_ENTER) {
-                            if (event == null || !event.isShiftPressed()) {
-                                // the user is done typing.
-                                login();
-                                return true; // consume.
-
-                            }
-                        }
-                        return false; // pass on to other listeners.
+                    public void run() {
+                        login();
                     }
-                }
+                })
         );
     }
 

--- a/app/src/main/java/com/greenaddress/greenbits/ui/WatchOnlyLoginActivity.java
+++ b/app/src/main/java/com/greenaddress/greenbits/ui/WatchOnlyLoginActivity.java
@@ -1,0 +1,158 @@
+package com.greenaddress.greenbits.ui;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.view.KeyEvent;
+import android.view.View;
+import android.view.inputmethod.EditorInfo;
+import android.widget.EditText;
+import android.widget.TextView;
+
+import com.dd.CircularProgressButton;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.greenaddress.greenapi.LoginData;
+import com.greenaddress.greenbits.GaService;
+
+public class WatchOnlyLoginActivity extends GaActivity {
+
+    private static final int REQUEST_SIGNUP = 0;
+    private EditText mUsernameText;
+    private EditText mPasswordText;
+    private CircularProgressButton mLoginButton;
+
+    @Override
+    protected void onCreateWithService(final Bundle savedInstanceState) {
+        setContentView(R.layout.activity_watchonly);
+
+        mUsernameText = (EditText) findViewById(R.id.input_user);
+        mPasswordText = (EditText) findViewById(R.id.input_password);
+        mLoginButton = (CircularProgressButton) findViewById(R.id.btn_login);
+
+        mLoginButton.setIndeterminateProgressMode(true);
+        mLoginButton.setOnClickListener(new View.OnClickListener() {
+
+            @Override
+            public void onClick(final View v) {
+                login();
+            }
+        });
+
+        mPasswordText.setOnEditorActionListener(
+                new EditText.OnEditorActionListener() {
+                    @Override
+                    public boolean onEditorAction(final TextView v, final int actionId, final KeyEvent event) {
+                        if (actionId == EditorInfo.IME_ACTION_SEARCH ||
+                                actionId == EditorInfo.IME_ACTION_DONE ||
+                                (event != null && event.getAction() == KeyEvent.ACTION_DOWN) &&
+                                        event.getKeyCode() == KeyEvent.KEYCODE_ENTER) {
+                            if (event == null || !event.isShiftPressed()) {
+                                // the user is done typing.
+                                login();
+                                return true; // consume.
+
+                            }
+                        }
+                        return false; // pass on to other listeners.
+                    }
+                }
+        );
+    }
+
+    private void login() {
+        if (mLoginButton.getProgress() != 0)
+            return;
+
+        if (!validate()) {
+            onLoginFailed(null);
+            return;
+        }
+
+        final String username = mUsernameText.getText().toString();
+        final String password = mPasswordText.getText().toString();
+
+        if (!mService.isConnected()) {
+            toast(R.string.err_send_not_connected_will_resume);
+            return;
+        }
+
+        onLoginBegin();
+
+        final ListenableFuture<LoginData> future = mService.watchOnlyLogin(username, password);
+
+        Futures.addCallback(future, new FutureCallback<LoginData>() {
+
+            @Override
+            public void onSuccess(final LoginData result) {
+                startActivity(new Intent(WatchOnlyLoginActivity.this, TabbedMainActivity.class));
+                finish();
+            }
+
+            @Override
+            public void onFailure(final Throwable t) {
+                runOnUiThread(new Runnable() {
+                    @Override
+                    public void run() {
+                        onLoginFailed(getString(R.string.error_username_not_found_or_wrong_password));
+                    }
+                });
+            }
+        });
+    }
+
+    @Override
+    protected void onActivityResult(final int requestCode, final int resultCode, final Intent data) {
+        if (requestCode == REQUEST_SIGNUP) {
+            if (resultCode == RESULT_OK) {
+
+                // TODO: Implement successful signup logic here
+                // By default we just finish the Activity and log them in automatically
+                this.finish();
+            }
+        }
+    }
+
+    @Override
+    public void onResumeWithService() {
+
+        final GaService service = mService;
+        if (service.isLoggedOrLoggingIn()) {
+            // already logged in, could be from different app via intent
+            startActivity(new Intent(this, TabbedMainActivity.class));
+            finish();
+        }
+    }
+
+    private void onLoginBegin() {
+        mLoginButton.setProgress(50);
+        mUsernameText.setEnabled(false);
+        mPasswordText.setEnabled(false);
+    }
+
+    private void onLoginFailed(final String msg) {
+        mLoginButton.setProgress(0);
+        mUsernameText.setEnabled(true);
+        mPasswordText.setEnabled(true);
+        if (msg != null) mPasswordText.setError(msg);
+    }
+
+    private boolean validate() {
+
+        if (mUsernameText.getText().length() == 0) {
+            mUsernameText.setError(getString(R.string.enter_valid_username));
+            return false;
+        } else {
+            mUsernameText.setError(null);
+        }
+
+        if (mPasswordText.getText().length() == 0) {
+            mPasswordText.setError(getString(R.string.enter_valid_password));
+            return false;
+        } else {
+            mPasswordText.setError(null);
+        }
+
+        return true;
+    }
+}

--- a/app/src/main/java/com/greenaddress/greenbits/ui/preferences/GaPreferenceActivity.java
+++ b/app/src/main/java/com/greenaddress/greenbits/ui/preferences/GaPreferenceActivity.java
@@ -10,8 +10,8 @@ import android.widget.Toast;
 
 import com.greenaddress.greenbits.GaService;
 import com.greenaddress.greenbits.GreenAddressApplication;
+import com.greenaddress.greenbits.ui.UI;
 import com.greenaddress.greenbits.ui.FirstScreenActivity;
-import com.greenaddress.greenbits.ui.GaActivity;
 
 
 // Our GaPreferenceActivity derived classes aren't exported publically, so the
@@ -87,9 +87,9 @@ public abstract class GaPreferenceActivity extends AppCompatPreferenceActivity {
     }
 
     public void toast(final String s) {
-        GaActivity.toastImpl(this, s, Toast.LENGTH_LONG);
+        UI.toast(this, s, Toast.LENGTH_LONG);
     }
     public void toast(final int id) {
-        GaActivity.toastImpl(this, id, Toast.LENGTH_LONG);
+        UI.toast(this, id, Toast.LENGTH_LONG);
     }
 }

--- a/app/src/main/java/com/greenaddress/greenbits/ui/preferences/GeneralPreferenceFragment.java
+++ b/app/src/main/java/com/greenaddress/greenbits/ui/preferences/GeneralPreferenceFragment.java
@@ -16,7 +16,7 @@ import com.afollestad.materialdialogs.DialogAction;
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
-import com.greenaddress.greenbits.ui.GaActivity;
+import com.greenaddress.greenbits.ui.UI;
 import com.greenaddress.greenbits.ui.PinSaveActivity;
 import com.greenaddress.greenbits.ui.R;
 
@@ -139,7 +139,7 @@ public class GeneralPreferenceFragment extends GAPreferenceFragment {
                     inputUser.setText(mService.getWatchOnlyUsername());
                 } catch (final Exception e) {}
                 final EditText inputPassword = (EditText) inflatedLayout.findViewById(R.id.input_password);
-                final MaterialDialog dialog = GaActivity.popup(getActivity(), R.string.watchOnlyLogin)
+                final MaterialDialog dialog = UI.popup(getActivity(), R.string.watchOnlyLogin)
                         .customView(inflatedLayout, true)
                         .onPositive(new MaterialDialog.SingleButtonCallback() {
                             @Override
@@ -149,7 +149,7 @@ public class GeneralPreferenceFragment extends GAPreferenceFragment {
                                 if (username.isEmpty() && password.isEmpty()) {
                                     try {
                                         mService.disableWatchOnly();
-                                        GaActivity.toastImpl(getActivity(), R.string.watchOnlyLoginDisabled, Toast.LENGTH_LONG);
+                                        UI.toast(getActivity(), R.string.watchOnlyLoginDisabled, Toast.LENGTH_LONG);
                                         watchOnlyLogin.setSummary(R.string.watchOnlyLoginSetup);
                                     } catch (Exception e) {
                                         e.printStackTrace();
@@ -161,7 +161,7 @@ public class GeneralPreferenceFragment extends GAPreferenceFragment {
                                     watchOnlyLogin.setSummary(getString(R.string.watchOnlyLoginStatus, username));
 
                                 } catch (final Exception e) {
-                                    GaActivity.toastImpl(getActivity(), R.string.error_username_not_available, Toast.LENGTH_LONG);
+                                    UI.toast(getActivity(), R.string.error_username_not_available, Toast.LENGTH_LONG);
                                 }
                             }
                         }).build();

--- a/app/src/main/java/com/greenaddress/greenbits/ui/preferences/SPVPreferenceFragment.java
+++ b/app/src/main/java/com/greenaddress/greenbits/ui/preferences/SPVPreferenceFragment.java
@@ -8,7 +8,7 @@ import android.preference.Preference;
 
 import com.afollestad.materialdialogs.DialogAction;
 import com.afollestad.materialdialogs.MaterialDialog;
-import com.greenaddress.greenbits.ui.GaActivity;
+import com.greenaddress.greenbits.ui.UI;
 import com.greenaddress.greenbits.ui.R;
 
 public class SPVPreferenceFragment extends GAPreferenceFragment
@@ -65,7 +65,7 @@ public class SPVPreferenceFragment extends GAPreferenceFragment
         if (s.isEmpty() || s.contains("."))
             return false;
 
-        GaActivity.popup(getActivity(), R.string.enterValidAddressTitle, android.R.string.ok)
+        UI.popup(getActivity(), R.string.enterValidAddressTitle, android.R.string.ok)
                   .content(R.string.enterValidAddressText).build().show();
         return true;
     }
@@ -111,7 +111,7 @@ public class SPVPreferenceFragment extends GAPreferenceFragment
                     (mService.getProxyHost() == null || mService.getProxyPort() == null)) {
                     // Certain ciphers have been deprecated in API 23+, breaking Orchid
                     // and HS connectivity (Works with Orbot socks proxy if set)
-                    GaActivity.popup(getActivity(), R.string.enterValidAddressTitleTorDisabled, android.R.string.ok)
+                    UI.popup(getActivity(), R.string.enterValidAddressTitleTorDisabled, android.R.string.ok)
                               .content(R.string.enterValidAddressTextTorDisabled).build().show();
                     return true;
                 }
@@ -121,7 +121,7 @@ public class SPVPreferenceFragment extends GAPreferenceFragment
             }
 
             // Force the user to confirm that they want to use a non-Tor host
-            GaActivity.popup(getActivity(), R.string.changingWarnOnionTitle)
+            UI.popup(getActivity(), R.string.changingWarnOnionTitle)
                       .content(R.string.changingWarnOnionText)
                       .onPositive(new MaterialDialog.SingleButtonCallback() {
                           @Override

--- a/app/src/main/java/com/greenaddress/greenbits/ui/preferences/TwoFactorPreferenceFragment.java
+++ b/app/src/main/java/com/greenaddress/greenbits/ui/preferences/TwoFactorPreferenceFragment.java
@@ -15,7 +15,7 @@ import com.afollestad.materialdialogs.MaterialDialog;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.greenaddress.greenbits.ui.CB;
-import com.greenaddress.greenbits.ui.GaActivity;
+import com.greenaddress.greenbits.ui.UI;
 import com.greenaddress.greenbits.ui.R;
 import com.greenaddress.greenbits.ui.TwoFactorActivity;
 
@@ -72,7 +72,7 @@ public class TwoFactorPreferenceFragment extends GAPreferenceFragment {
         }
 
         final boolean skipChoice = false;
-        final Dialog dlg = GaActivity.popupTwoFactorChoice(getActivity(), mService, skipChoice,
+        final Dialog dlg = UI.popupTwoFactorChoice(getActivity(), mService, skipChoice,
                                                      new CB.Runnable1T<String>() {
             @Override
             public void run(final String whichMethod) {
@@ -105,7 +105,7 @@ public class TwoFactorPreferenceFragment extends GAPreferenceFragment {
         }
         prompt.setText(getString(R.string.twoFacProvideConfirmationCode, withMethodName));
 
-        GaActivity.popup(this.getActivity(), "2FA")
+        UI.popup(this.getActivity(), "2FA")
                   .customView(inflatedLayout, true)
                   .onPositive(new MaterialDialog.SingleButtonCallback() {
                       @Override

--- a/app/src/main/res/layout/activity_watchonly.xml
+++ b/app/src/main/res/layout/activity_watchonly.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:paddingLeft="24dp"
+        android:paddingRight="24dp"
+        android:paddingTop="56dp">
+
+        <android.support.design.widget.TextInputLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="8dp"
+            android:layout_marginTop="8dp">
+
+            <EditText
+                android:id="@+id/input_user"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/username"
+                android:inputType="textNoSuggestions" />
+        </android.support.design.widget.TextInputLayout>
+
+        <android.support.design.widget.TextInputLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="8dp"
+            android:layout_marginTop="8dp">
+
+            <com.maksim88.passwordedittext.PasswordEditText
+                android:id="@+id/input_password"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/password"
+                android:inputType="textPassword" />
+        </android.support.design.widget.TextInputLayout>
+
+        <com.dd.CircularProgressButton
+            android:id="@+id/btn_login"
+            style="@style/myButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
+            android:layout_marginBottom="24dp"
+            android:layout_marginTop="24dp"
+            android:padding="12dp"
+            android:text="@string/pinLoginText"
+            android:textColor="@color/white"
+            app:cpb_colorIndicator="@color/accent"
+            app:cpb_selectorIdle="@drawable/buttonprogressselector"
+            app:cpb_textIdle="@string/pinLoginText" />
+        
+    </LinearLayout>
+</ScrollView>

--- a/app/src/main/res/layout/dialog_set_watchonly.xml
+++ b/app/src/main/res/layout/dialog_set_watchonly.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/username"
+        android:textColor="@color/whiteSecondary"
+        android:textSize="20sp" />
+
+    <EditText
+        android:id="@+id/input_user"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textColor="@color/white"
+        android:inputType="textNoSuggestions" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/password"
+        android:textColor="@color/whiteSecondary"
+        android:textSize="20sp" />
+
+    <com.maksim88.passwordedittext.PasswordEditText
+        android:id="@+id/input_password"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textColor="@color/white"
+        android:inputType="textPassword" />
+
+</LinearLayout>

--- a/app/src/main/res/menu/preauth_menu.xml
+++ b/app/src/main/res/menu/preauth_menu.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@+id/proxy_preferences"
+        android:title="@string/pref_header_proxy"
+        android:visible="false" />
+    <item
+        android:id="@+id/watchonly_preference"
+        android:title="@string/watchOnlyLogin" />
+</menu>

--- a/app/src/main/res/menu/proxy_menu.xml
+++ b/app/src/main/res/menu/proxy_menu.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<menu
-    xmlns:android="http://schemas.android.com/apk/res/android">
-    <item
-        android:id="@+id/proxy_preferences"
-        android:title="Proxy"/>
-</menu>

--- a/app/src/main/res/menu/watchonly.xml
+++ b/app/src/main/res/menu/watchonly.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:id="@+id/network_unavailable"
+        android:icon="@drawable/plug_ffffff"
+        android:orderInCategory="90"
+        android:title="@string/network_unavailable"
+        android:visible="false"
+        app:showAsAction="always" />
+
+    <item
+        android:id="@+id/action_logout"
+        android:orderInCategory="60"
+        android:title="@string/action_logout"
+        app:showAsAction="never" />
+
+    <item
+        android:id="@+id/action_about"
+        android:orderInCategory="55"
+        android:title="@string/action_about"
+        app:showAsAction="never" />
+</menu>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -183,4 +183,11 @@
   <string name="trustedspvExample">Per esempio: 8.90.14.2:8333,40.116.12.85:8333</string>
   <string name="view_block_explorer">Sei sicuro di voler mandare al block explorer %1$s i dettagli?</string>
   <string name="no_peers_connected">Nessun Nodo Connesso</string>
+  <string name="watchOnlyLoginStatus">Abilitato: %1$s</string>
+  <string name="watchOnlyLoginSetup">Tocca per configurare</string>
+  <string name="watchOnlyLoginDisabled">Watch Only disabilitato</string>
+  <string name="enter_valid_username">Per piacere inserisci un valido username</string>
+  <string name="enter_valid_password">La password non deve essere vuota</string>
+  <string name="error_username_not_found_or_wrong_password">Utente inesistente o password non corretta</string>
+  <string name="error_username_not_available">Username non disponibile</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -221,4 +221,14 @@
     <string name="no_peers_connected">No Peers Connected</string>
     <string name="settings_currency">Fiat exchange currency</string>
     <string name="settings_denomination">Bitcoin denomination</string>
+    <string name="watchOnlyLogin">Watch only login</string>
+    <string name="watchOnlyLoginStatus">Enabled: %1$s</string>
+    <string name="watchOnlyLoginSetup">Touch to setup</string>
+    <string name="watchOnlyLoginDisabled">Watch Only disabled</string>
+    <string name="password">Password</string>
+    <string name="username">Username</string>
+    <string name="enter_valid_username">Please enter a valid username</string>
+    <string name="enter_valid_password">The password can\'t be empty</string>
+    <string name="error_username_not_found_or_wrong_password">User not found or invalid password</string>
+    <string name="error_username_not_available">Username not available</string>
 </resources>

--- a/app/src/main/res/xml/preference_general.xml
+++ b/app/src/main/res/xml/preference_general.xml
@@ -26,6 +26,12 @@
     <CheckBoxPreference android:key="optin_rbf"
                         android:title="@string/optin_rbf" />
 
+    <Preference android:key="watch_only_login"
+        android:title="@string/watchOnlyLogin"
+        android:defaultValue=""
+        android:summary="">
+    </Preference>
+
     <Preference android:key="ledger_wallet"
                 android:title="@string/improve_security_ledger"
                 android:dependency=""


### PR DESCRIPTION
- Added support for setup/current status in settings
- Added support to login (no send tab or no settings available, nor transaction replacement)
- Cleaned up in separate commits emerging commonality between signed login and watch only