### PR TITLE
Prefer TextUtils.isEmpty() to null+isEmpty checks

### DIFF
--- a/app/src/main/java/com/greenaddress/greenapi/WalletClient.java
+++ b/app/src/main/java/com/greenaddress/greenapi/WalletClient.java
@@ -1,5 +1,6 @@
 package com.greenaddress.greenapi;
 
+import android.text.TextUtils;
 import android.util.Log;
 
 import com.blockstream.libwally.Wally;
@@ -532,7 +533,7 @@ public class WalletClient {
     }
 
     public boolean isWatchOnly() {
-        return mWatchOnlyUsername != null && !mWatchOnlyUsername.isEmpty() && mWatchOnlyPassword != null && !mWatchOnlyPassword.isEmpty();
+        return !TextUtils.isEmpty(mWatchOnlyUsername) && !TextUtils.isEmpty(mWatchOnlyPassword);
     }
 
     public boolean registerWatchOnly(final String username, final String password) throws Exception {

--- a/app/src/main/java/com/greenaddress/greenbits/ui/ListTransactionsAdapter.java
+++ b/app/src/main/java/com/greenaddress/greenbits/ui/ListTransactionsAdapter.java
@@ -6,6 +6,7 @@ import android.content.res.Resources;
 import android.graphics.Color;
 import android.support.v7.widget.RecyclerView;
 import android.text.Html;
+import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -102,16 +103,18 @@ public class ListTransactionsAdapter extends
                 && txItem.counterparty != null && txItem.counterparty.length() > 0
                 && !GaService.isValidAddress(txItem.counterparty);
 
-        final String message = txItem.memo == null || txItem.memo.isEmpty() ?
-                humanCpty ?
-                        txItem.counterparty
-                        :
-                        getTypeString(txItem.type)
-                :
-                humanCpty ?
-                        String.format("%s %s", txItem.counterparty, txItem.memo)
-                        :
-                        txItem.memo;
+        final String message;
+        if (TextUtils.isEmpty(txItem.memo)) {
+            if (humanCpty)
+                message = txItem.counterparty;
+            else
+                message = getTypeString(txItem.type);
+        } else {
+            if (humanCpty)
+                message = String.format("%s %s", txItem.counterparty, txItem.memo);
+            else
+                message = txItem.memo;
+        }
 
         holder.textWho.setText(message);
 

--- a/app/src/main/java/com/greenaddress/greenbits/ui/SendFragment.java
+++ b/app/src/main/java/com/greenaddress/greenbits/ui/SendFragment.java
@@ -9,6 +9,7 @@ import android.os.Bundle;
 import android.support.v4.view.ViewPager;
 import android.text.Editable;
 import android.text.Html;
+import android.text.TextUtils;
 import android.text.TextWatcher;
 import android.util.Log;
 import android.util.TypedValue;
@@ -92,7 +93,7 @@ public class SendFragment extends SubaccountFragment {
 
         amountScale.setText(Html.fromHtml(prefix));
         feeScale.setText(Html.fromHtml(prefix));
-        if (prefix == null || prefix.isEmpty()) {
+        if (TextUtils.isEmpty(prefix)) {
             amountUnit.setText("bits ");
             feeUnit.setText("bits ");
         } else {


### PR DESCRIPTION
We should probably use TextUtils everywhere we currently use isEmpty as well, but I'll leave that for another change.