### PR TITLE
Return to the mnemonics screen if the user cancels PIN entry

### DIFF
--- a/app/src/main/java/com/greenaddress/greenbits/GaService.java
+++ b/app/src/main/java/com/greenaddress/greenbits/GaService.java
@@ -124,6 +124,7 @@ public class GaService extends Service {
     private Map<?, ?> twoFacConfig;
     private final GaObservable twoFacConfigObservable = new GaObservable();
     private String deviceId;
+    private boolean mUserCancelledPINEntry = false;
 
     public final SPV spv = new SPV(this);
 
@@ -164,6 +165,14 @@ public class GaService extends Service {
                 t.printStackTrace();
             }
         }, es);
+    }
+
+    public boolean getUserCancelledPINEntry() {
+        return mUserCancelledPINEntry;
+    }
+
+    public void setUserCancelledPINEntry(final boolean value) {
+        mUserCancelledPINEntry = value;
     }
 
     private void reconnect() {

--- a/app/src/main/java/com/greenaddress/greenbits/ui/FirstScreenActivity.java
+++ b/app/src/main/java/com/greenaddress/greenbits/ui/FirstScreenActivity.java
@@ -292,12 +292,16 @@ public class FirstScreenActivity extends GaActivity {
     public void onResumeWithService() {
         final GaService service = mService;
 
+        // Make a note if the user cancelled PIN entry
+        final boolean userCancelled = service.getUserCancelledPINEntry();
+        service.setUserCancelledPINEntry(false);
+
         //FIXME : recheck state, properly handle TEE link anyway
         if (service.isLoggedIn()) {
             // already logged in, could be from different app via intent
             startNewActivity(TabbedMainActivity.class);
             finish();
-        } else if (service.cfg("pin").getString("ident", null) != null) {
+        } else if (service.cfg("pin").getString("ident", null) != null && !userCancelled) {
             startNewActivity(PinActivity.class);
             finish();
         }

--- a/app/src/main/java/com/greenaddress/greenbits/ui/PinActivity.java
+++ b/app/src/main/java/com/greenaddress/greenbits/ui/PinActivity.java
@@ -254,14 +254,18 @@ public class PinActivity extends GaActivity implements Observer {
 
     @Override
     protected void onActivityResult(final int requestCode, final int resultCode, final Intent data) {
+        final GaService service = mService;
+
         if (requestCode == ACTIVITY_REQUEST_CODE) {
             // Challenge completed, proceed with using cipher
             if (resultCode == RESULT_OK) {
                 tryDecrypt();
             } else {
                 // The user canceled or didn’t complete the lock screen
-                // operation. Go to error/cancellation flow.
-                toast("Authentication not provided, closing.");
+                // operation. Go back to the initial login screen to allow
+                // them to enter mnemonics.
+                service.setUserCancelledPINEntry(true);
+                startActivity(new Intent(this, FirstScreenActivity.class));
                 finish();
             }
         }


### PR DESCRIPTION
This allows the user to login using mnemonics if they have forgotten
their PIN or a something unexpected causes it to become inaccessable.