### PR TITLE
Run finish in ui thread

### DIFF
--- a/app/src/main/java/com/greenaddress/greenbits/ui/WatchOnlyLoginActivity.java
+++ b/app/src/main/java/com/greenaddress/greenbits/ui/WatchOnlyLoginActivity.java
@@ -72,7 +72,7 @@ public class WatchOnlyLoginActivity extends GaActivity {
             @Override
             public void onSuccess(final LoginData result) {
                 startActivity(new Intent(WatchOnlyLoginActivity.this, TabbedMainActivity.class));
-                finish();
+                finishOnUiThread();
             }
 
             @Override
@@ -94,7 +94,7 @@ public class WatchOnlyLoginActivity extends GaActivity {
 
                 // TODO: Implement successful signup logic here
                 // By default we just finish the Activity and log them in automatically
-                this.finish();
+                finish();
             }
         }
     }


### PR DESCRIPTION
Some cleanups/fixes ensuring that Activity.finish() is not called from background threads. This is one class of error resulting from extensive use of futures (other UI calls will be tackled separately).