### PR TITLE
add cert pinning for all envs minus regtest

### DIFF
--- a/app/src/alpha/java/com/greenaddress/greenapi/Network.java
+++ b/app/src/alpha/java/com/greenaddress/greenapi/Network.java
@@ -5,6 +5,7 @@ import org.bitcoinj.core.NetworkParameters;
 public abstract class Network {
     public final static NetworkParameters NETWORK = NetworkParameters.fromID(NetworkParameters.ID_TESTNET);
     public final static String GAIT_WAMP_URL = "wss://alphawss.greenaddress.it/ws/inv";
+    public final static String GAIT_WAMP_CERT_PIN = "BE:26:87:C9:37:98:B3:4E:70:22:0D:18:FE:9E:39:7F:15:7E:0A:F8";
     public final static String BLOCKEXPLORER_ADDRESS = "https://test-insight.bitpay.com/address/";
     public final static String BLOCKEXPLORER_TX = "https://test-insight.bitpay.com/tx/";
     public final static String depositPubkey = "036307e560072ed6ce0aa5465534fb5c258a2ccfbc257f369e8e7a181b16d897b3";

--- a/app/src/btctestnet/java/com/greenaddress/greenapi/Network.java
+++ b/app/src/btctestnet/java/com/greenaddress/greenapi/Network.java
@@ -5,6 +5,7 @@ import org.bitcoinj.core.NetworkParameters;
 public abstract class Network {
     public final static NetworkParameters NETWORK = NetworkParameters.fromID(NetworkParameters.ID_TESTNET);
     public final static String GAIT_WAMP_URL = "wss://testwss.greenaddress.it/v2/ws/";
+    public final static String GAIT_WAMP_CERT_PIN = "BE:26:87:C9:37:98:B3:4E:70:22:0D:18:FE:9E:39:7F:15:7E:0A:F8";
     public final static String BLOCKEXPLORER_ADDRESS = "https://sandbox.smartbit.com.au/address/";
     public final static String BLOCKEXPLORER_TX = "https://sandbox.smartbit.com.au/tx/";
     public final static String depositPubkey = "036307e560072ed6ce0aa5465534fb5c258a2ccfbc257f369e8e7a181b16d897b3";

--- a/app/src/main/java/com/greenaddress/greenbits/GaService.java
+++ b/app/src/main/java/com/greenaddress/greenbits/GaService.java
@@ -200,6 +200,7 @@ public class GaService extends Service {
 
             @Override
             public void onFailure(final Throwable t) {
+                t.printStackTrace();
                 Log.i(TAG, "Failure throwable callback " + t.toString());
                 mState.transitionTo(ConnState.DISCONNECTED);
                 scheduleReconnect();

--- a/app/src/production/java/com/greenaddress/greenapi/Network.java
+++ b/app/src/production/java/com/greenaddress/greenapi/Network.java
@@ -5,6 +5,7 @@ import org.bitcoinj.core.NetworkParameters;
 public abstract class Network {
     public final static NetworkParameters NETWORK = NetworkParameters.fromID(NetworkParameters.ID_MAINNET);
     public final static String GAIT_WAMP_URL = "wss://prodwss.greenaddress.it/v2/ws/";
+    public final static String GAIT_WAMP_CERT_PIN = "BE:26:87:C9:37:98:B3:4E:70:22:0D:18:FE:9E:39:7F:15:7E:0A:F8";
     public final static String BLOCKEXPLORER_ADDRESS = "https://www.smartbit.com.au/address/";
     public final static String BLOCKEXPLORER_TX = "https://www.smartbit.com.au/tx/";
     public final static String depositPubkey = "0322c5f5c9c4b9d1c3e22ca995e200d724c2d7d8b6953f7b38fddf9296053c961f";

--- a/app/src/regtest/java/com/greenaddress/greenapi/Network.java
+++ b/app/src/regtest/java/com/greenaddress/greenapi/Network.java
@@ -5,6 +5,7 @@ import org.bitcoinj.core.NetworkParameters;
 public abstract class Network {
     public final static NetworkParameters NETWORK = NetworkParameters.fromID(NetworkParameters.ID_REGTEST);
     public final static String GAIT_WAMP_URL = "ws://10.0.2.2:8080/v2/ws/";
+    public final static String GAIT_WAMP_CERT_PIN = null;
     public final static String BLOCKEXPLORER_ADDRESS = "http://192.168.56.1:8080/address/";
     public final static String BLOCKEXPLORER_TX = "http://192.168.56.1:8080/tx/";
     public final static String depositChainCode = "b60befcc619bb1c212732770fe181f2f1aa824ab89f8aab49f2e13e3a56f0f04";


### PR DESCRIPTION
add cert pinning for all envs minus regtest

no alert in case cert validation fails - reconnect rescheduled

Maybe we want to add a notification to the user that his network is being manipulated