### PR TITLE
Show the disconnected menu indicator immediately on PIN entry

### DIFF
--- a/app/src/main/java/com/greenaddress/greenbits/ui/PinActivity.java
+++ b/app/src/main/java/com/greenaddress/greenbits/ui/PinActivity.java
@@ -304,6 +304,7 @@ public class PinActivity extends GaActivity implements Observer {
         getMenuInflater().inflate(R.menu.common_menu, menu);
         getMenuInflater().inflate(R.menu.preauth_menu, menu);
         mMenu = menu;
+        setMenuItemVisible(mMenu, R.id.network_unavailable, !mService.isConnected());
         return true;
     }
 


### PR DESCRIPTION
Its otherwise rather frustrating to mash the enter button while
waiting to connect.