### PR TITLE
Fix bitcoinj's DownloadProgressTracker on sync completion

### DIFF
--- a/bitcoinj/core/src/main/java/org/bitcoinj/core/listeners/DownloadProgressTracker.java
+++ b/bitcoinj/core/src/main/java/org/bitcoinj/core/listeners/DownloadProgressTracker.java
@@ -66,8 +66,13 @@ public class DownloadProgressTracker extends AbstractPeerDataEventListener {
 
         if (blocksLeft == 0) {
             caughtUp = true;
+            if (lastPercent != 100) {
+                lastPercent = 100;
+                progress(lastPercent, blocksLeft, new Date(block.getTimeSeconds() * 1000));
+            }
             doneDownload();
             future.set(peer.getBestHeight());
+            return;
         }
 
         if (blocksLeft < 0 || originalBlocksLeft <= 0)


### PR DESCRIPTION
Previous behaviour was to call progress() after doneDownload which
is counterintuitive and incorrect.