### PR TITLE
Spv initial hang

### DIFF
--- a/app/src/main/java/com/greenaddress/greenbits/spv/PeerFilterProvider.java
+++ b/app/src/main/java/com/greenaddress/greenbits/spv/PeerFilterProvider.java
@@ -14,21 +14,12 @@ class PeerFilterProvider implements org.bitcoinj.core.PeerFilterProvider {
 
     @Override
     public int getBloomFilterElementCount() {
-        // 1 to avoid downloading full blocks (empty bloom filters are ignored by bitcoinj)
-        final int count = mSPV.getUnspentOutpointsSize();
-        return count == 0 ? 1 : count;
+        return mSPV.getBloomFilterElementCount();
     }
 
     @Override
     public BloomFilter getBloomFilter(final int size, final double falsePositiveRate, final long nTweak) {
-
-        final BloomFilter filter = new BloomFilter(size, falsePositiveRate, nTweak);
-        if (mSPV.populateBloomFilter(filter) == 0) {
-            // Add a fake entry to avoid downloading blocks when filter is empty,
-            // as empty bloom filters are ignored by bitcoinj.
-            filter.insert(new byte[]{(byte) 0xde, (byte) 0xad, (byte) 0xbe, (byte) 0xef});
-        }
-        return filter;
+        return mSPV.getBloomFilter(size, falsePositiveRate, nTweak);
     }
 
     @Override

--- a/app/src/main/java/com/greenaddress/greenbits/spv/SPV.java
+++ b/app/src/main/java/com/greenaddress/greenbits/spv/SPV.java
@@ -289,14 +289,6 @@ public class SPV {
             mService.fireBalanceChanged(subAccount);
     }
 
-    private void resetUnspent() {
-        Log.d(TAG, "resetUnspent");
-        mUnspentDetails.clear();
-        mUnspentOutpoints.clear();
-        mCountedUtxoValues.clear();
-        mVerifiedCoinBalances.clear();
-    }
-
     private void updateBalance(final TransactionOutPoint txOutpoint, final int subAccount, final Coin addValue) {
         if (mCountedUtxoValues.containsKey(txOutpoint))
            return;
@@ -813,7 +805,10 @@ public class SPV {
 
             if (deleteUnspent) {
                 Log.d(TAG, "Resetting unspent outputs");
-                resetUnspent();
+                mUnspentDetails.clear();
+                mUnspentOutpoints.clear();
+                mCountedUtxoValues.clear();
+                mVerifiedCoinBalances.clear();
             }
 
             if (isEnabled()) {


### PR DESCRIPTION
Try to work around the sporadic hangs we see on SPV startup. This appears to be caused by updating the bloom filter once syncing has already started. So we instead populate the bloom filter beforehand.