### PR TITLE
use per wallet preference for subwallet 

### DIFF
--- a/app/src/main/java/com/greenaddress/greenbits/GaService.java
+++ b/app/src/main/java/com/greenaddress/greenbits/GaService.java
@@ -251,8 +251,8 @@ public class GaService extends Service implements INotificationHandler {
     public String getProxyPort() { return cfg().getString("proxy_port", ""); }
     public boolean getTorEnabled() { return cfg().getBoolean("tor_enabled", false); }
     public boolean isProxyEnabled() { return !TextUtils.isEmpty(getProxyHost()) && !TextUtils.isEmpty(getProxyPort()); }
-    public int getCurrentSubAccount() { return cfg("main").getInt("curSubaccount", 0); }
-    public void setCurrentSubAccount(int subAccount) { cfgEdit("main").putInt("curSubaccount", subAccount).apply(); }
+    public int getCurrentSubAccount() { return cfgIn("CONFIG").getInt("current_subaccount", 0); }
+    public void setCurrentSubAccount(final int subAccount) { cfgInEdit("CONFIG").putInt("current_subaccount", subAccount).apply(); }
     public boolean showBalanceInTitle() { return cfg().getBoolean("show_balance_in_title", false); }
 
     // SPV


### PR DESCRIPTION
…device

This fixes a bug that can happen if you access from the same device different wallets that have a different number of subwallet.

This prevents the app from attempting to listen for subwallet that are not available in a wallet.

i.e.

`java.lang.RuntimeException: Unable to start activity ComponentInfo{com.greenaddress.greenbits_android_wallet/com.greenaddress.greenbits.ui.TabbedMainActivity}: java.lang.NullPointerException: Attempt to invoke virtual method 'void com.greenaddress.greenbits.GaService$GaObservable.addObserver(java.util.Observer)' on a null object reference
	at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2416)
	at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2476)
	at android.app.ActivityThread.-wrap11(ActivityThread.java)
	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1344)
	at android.os.Handler.dispatchMessage(Handler.java:102)
	at android.os.Looper.loop(Looper.java:148)
	at android.app.ActivityThread.main(ActivityThread.java:5422)
	at java.lang.reflect.Method.invoke(Method.java)
	at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:726)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:616)
Caused by: java.lang.NullPointerException: Attempt to invoke virtual method 'void com.greenaddress.greenbits.GaService$GaObservable.addObserver(java.util.Observer)' on a null object reference
	at com.greenaddress.greenbits.GaService.addBalanceObserver(GaService.java:763)
	at com.greenaddress.greenbits.ui.MainFragment.onCreateView(MainFragment.java:160)
	at android.support.v4.app.Fragment.performCreateView(Fragment.java:2080)
	at android.support.v4.app.FragmentManagerImpl.moveToState(FragmentManagerImpl.java:1108)
	at android.support.v4.app.FragmentManagerImpl.moveToState(FragmentManagerImpl.java:1290)
	at android.support.v4.app.FragmentManagerImpl.moveToState(FragmentManagerImpl.java:1272)
	at android.support.v4.app.FragmentManagerImpl.dispatchActivityCreated(FragmentManagerImpl.java:2149)
	at android.support.v4.app.FragmentActivity.onStart(FragmentActivity.java:201)
	at android.support.v7.app.AppCompatActivity.onStart(AppCompatActivity.java:178)
	at android.app.Instrumentation.callActivityOnStart(Instrumentation.java:1237)
	at android.app.Activity.performStart(Activity.java:6268)
	at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2379)
	... 9 more`