### PR TITLE
Fix tx view not updating when subaccount changed in another page

### DIFF
--- a/app/src/main/java/com/greenaddress/greenbits/ui/MainFragment.java
+++ b/app/src/main/java/com/greenaddress/greenbits/ui/MainFragment.java
@@ -41,6 +41,7 @@ public class MainFragment extends SubaccountFragment {
     private int curSubaccount;
     private Observer mVerifiedTxObserver;
     private Observer mNewTxObserver;
+    private boolean mIsDirty = false;
 
     private void updateBalance() {
         final GaService service = getGAService();
@@ -338,6 +339,11 @@ public class MainFragment extends SubaccountFragment {
     protected void onSubaccountChanged(final int newSubAccount) {
         curSubaccount = newSubAccount;
         makeBalanceObserver(curSubaccount);
+        if (!IsPageSelected()) {
+            Log.d(TAG, "Subaccount changed while page hidden");
+            mIsDirty = true;
+            return;
+        }
         reloadTransactions(false, true);
         updateBalance();
     }
@@ -347,6 +353,17 @@ public class MainFragment extends SubaccountFragment {
         super.setUserVisibleHint(isVisibleToUser);
         if (isVisibleToUser) {
             hideKeyboard();
+        }
+    }
+
+    public void setPageSelected(final boolean isSelected) {
+        final boolean needReload = isSelected && !IsPageSelected() && mIsDirty;
+        super.setPageSelected(isSelected);
+        if (needReload) {
+            Log.d(TAG, "Dirty, reloading");
+            reloadTransactions(false, true);
+            updateBalance();
+            mIsDirty = false;
         }
     }
 }

--- a/app/src/main/java/com/greenaddress/greenbits/ui/MainFragment.java
+++ b/app/src/main/java/com/greenaddress/greenbits/ui/MainFragment.java
@@ -219,6 +219,11 @@ public class MainFragment extends SubaccountFragment {
 
     // Called when a new transaction is seen
     private void onNewTx() {
+        if (!IsPageSelected()) {
+            Log.d(TAG, "New transaction while page hidden");
+            mIsDirty = true;
+            return;
+        }
         reloadTransactions(false, false);
     }
 


### PR DESCRIPTION
This also reduces many uneeded roundtrips by delaying them until the viewer selects the page again.