### PR TITLE
Tag dispatcher can be null if we are paused before the view is created

### DIFF
--- a/app/src/main/java/com/greenaddress/greenbits/ui/ReceiveFragment.java
+++ b/app/src/main/java/com/greenaddress/greenbits/ui/ReceiveFragment.java
@@ -59,7 +59,8 @@ public class ReceiveFragment extends SubaccountFragment implements OnDiscoveredT
             mQrCodeDialog.dismiss();
             mQrCodeDialog = null;
         }
-        mTagDispatcher.disableExclusiveNfc();
+        if (mTagDispatcher != null)
+            mTagDispatcher.disableExclusiveNfc();
     }
 
     @Override


### PR DESCRIPTION
Guard against this to prevent an NPE.