### PR TITLE
fixed text resize in FontFitEditText

### DIFF
--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+<declare-styleable name="FontFitEditText">
+    <attr name="textSizeMax" format="dimension"/>
+    <attr name="textSizeMin" format="dimension"/>
+</declare-styleable>
+</resources>


### PR DESCRIPTION
Now use dp instead px to resize text because px scaling could create different results on different devices.