### PR TITLE
Android automatic refactor - ObsoleteLayoutParam

### DIFF
--- a/app/src/main/res/layout-land/activity_two_factor_3_gauth_details.xml
+++ b/app/src/main/res/layout-land/activity_two_factor_3_gauth_details.xml
@@ -1,142 +1,126 @@
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools" android:layout_width="match_parent"
-    android:layout_height="match_parent" android:paddingLeft="@dimen/activity_horizontal_margin"
-    android:paddingRight="@dimen/activity_horizontal_margin"
-    android:paddingTop="@dimen/activity_vertical_margin"
-    android:paddingBottom="@dimen/activity_vertical_margin"
-    tools:context="com.greenaddress.greenbits.ui.TwoFactorActivity"
-    android:padding="0dp">
+<?xml version='1.0' encoding='UTF-8'?>
+  <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:tools="http://schemas.android.com/tools"
+  android:layout_width="match_parent"
+  android:layout_height="match_parent"
+  android:paddingLeft="@dimen/activity_horizontal_margin"
+  android:paddingRight="@dimen/activity_horizontal_margin"
+  android:paddingTop="@dimen/activity_vertical_margin"
+  android:paddingBottom="@dimen/activity_vertical_margin"
+  tools:context="com.greenaddress.greenbits.ui.TwoFactorActivity"
+  android:padding="0dp">
 
-    <LinearLayout
-        android:orientation="vertical"
-        android:layout_width="fill_parent"
-        android:layout_height="fill_parent"
-        android:layout_centerHorizontal="true"
-        android:layout_alignParentTop="true">
+  <LinearLayout android:orientation="vertical"
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent"
+    android:layout_centerHorizontal="true"
+    android:layout_alignParentTop="true">
 
-        <LinearLayout
-            android:orientation="horizontal"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center_horizontal"
-            android:padding="10sp"
-            android:background="#d7d7d7">
+    <LinearLayout android:orientation="horizontal"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:layout_gravity="center_horizontal"
+      android:padding="10sp"
+      android:background="#d7d7d7">
 
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/progress" />
+      <TextView android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/progress"/>
 
-            <ProgressBar
-                style="@style/myProgressBar"
-                android:layout_width="match_parent"
-                android:layout_height="3sp"
-                android:id="@+id/progressBar"
-                android:max="4"
-                android:progress="1"
-                android:paddingLeft="10sp"
-                android:layout_gravity="center_vertical" />
-
-        </LinearLayout>
-
-        <LinearLayout
-            android:orientation="horizontal"
-            android:layout_width="fill_parent"
-            android:layout_height="fill_parent"
-            android:padding="20sp">
-
-            <ScrollView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_weight="3">
-
-                <LinearLayout
-                    android:orientation="vertical"
-                    android:layout_width="fill_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="3"
-                    android:layout_marginRight="10dp">
-
-                    <TextView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:text="@string/twoFacProvideGauthDetailsDescription"
-                        android:id="@+id/description"
-                        android:layout_gravity="center_horizontal"
-                        android:layout_marginTop="0dp"
-                        android:layout_marginBottom="10sp"
-                        android:layout_weight="1" />
-
-                    <ImageView
-                        android:layout_width="110dp"
-                        android:layout_height="110dp"
-                        android:contentDescription="Google Authenticator QrCode"
-                        android:id="@+id/imageView"
-                        android:layout_gravity="center_horizontal"
-                        android:layout_weight="2"
-                        android:adjustViewBounds="false" />
-
-                    <TextView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:text="@string/twoFacGauthTextCode"
-                        android:id="@+id/textCode"
-                        android:layout_gravity="center_horizontal"
-                        android:layout_marginTop="10sp"
-                        android:layout_marginBottom="10sp"
-                        android:layout_weight="1" />
-                </LinearLayout>
-            </ScrollView>
-
-            <LinearLayout
-                android:orientation="vertical"
-                android:layout_width="fill_parent"
-                android:layout_height="wrap_content"
-                android:layout_weight="5"
-                android:layout_marginLeft="10dp">
-
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/twoFacProvideGauthDetails"
-                    android:id="@+id/prompt"
-                    android:layout_gravity="left"
-                    android:layout_marginTop="0dp"
-                    android:layout_marginBottom="10sp"
-                    android:textAppearance="@style/Base.TextAppearance.AppCompat.Medium"
-                    android:layout_weight="1" />
-
-                <EditText
-                    android:layout_width="fill_parent"
-                    android:layout_height="wrap_content"
-                    android:inputType="number"
-                    android:ems="10"
-                    android:id="@+id/code" />
-
-                <LinearLayout
-                    android:orientation="vertical"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="center_horizontal"
-                    android:id="@+id/emailNotices"
-                    android:visibility="gone"/>
-
-            </LinearLayout>
-
-        </LinearLayout>
-
+      <ProgressBar style="@style/myProgressBar"
+        android:layout_width="match_parent"
+        android:layout_height="3sp"
+        android:id="@+id/progressBar"
+        android:max="4"
+        android:progress="1"
+        android:paddingLeft="10sp"
+        android:layout_gravity="center_vertical"/>
     </LinearLayout>
 
-    <Button
-        android:layout_width="wrap_content"
+    <LinearLayout android:orientation="horizontal"
+      android:layout_width="fill_parent"
+      android:layout_height="fill_parent"
+      android:padding="20sp">
+
+      <ScrollView android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="@string/continueText"
-        android:textColor="@color/white"
-        android:id="@+id/continueButton"
-        android:layout_gravity="end"
-        style="@style/myButton"
-        android:layout_alignParentBottom="true"
-        android:layout_alignParentRight="true"
-        android:layout_alignParentEnd="true"
-        android:layout_margin="20sp" />
+        android:layout_weight="3">
+
+        <LinearLayout android:orientation="vertical"
+          android:layout_width="fill_parent"
+          android:layout_height="wrap_content"
+          android:layout_marginRight="10dp">
+
+          <TextView android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/twoFacProvideGauthDetailsDescription"
+            android:id="@+id/description"
+            android:layout_gravity="center_horizontal"
+            android:layout_marginTop="0dp"
+            android:layout_marginBottom="10sp"
+            android:layout_weight="1"/>
+
+          <ImageView android:layout_width="110dp"
+            android:layout_height="110dp"
+            android:contentDescription="Google Authenticator QrCode"
+            android:id="@+id/imageView"
+            android:layout_gravity="center_horizontal"
+            android:layout_weight="2"
+            android:adjustViewBounds="false"/>
+
+          <TextView android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/twoFacGauthTextCode"
+            android:id="@+id/textCode"
+            android:layout_gravity="center_horizontal"
+            android:layout_marginTop="10sp"
+            android:layout_marginBottom="10sp"
+            android:layout_weight="1"/>
+          <!--Removed ObsoleteLayoutParam: layout_weight-->
+        </LinearLayout>
+      </ScrollView>
+
+      <LinearLayout android:orientation="vertical"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:layout_weight="5"
+        android:layout_marginLeft="10dp">
+
+        <TextView android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="@string/twoFacProvideGauthDetails"
+          android:id="@+id/prompt"
+          android:layout_gravity="left"
+          android:layout_marginTop="0dp"
+          android:layout_marginBottom="10sp"
+          android:textAppearance="@style/Base.TextAppearance.AppCompat.Medium"
+          android:layout_weight="1"/>
+
+        <EditText android:layout_width="fill_parent"
+          android:layout_height="wrap_content"
+          android:inputType="number"
+          android:ems="10"
+          android:id="@+id/code"/>
+
+        <LinearLayout android:orientation="vertical"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:layout_gravity="center_horizontal"
+          android:id="@+id/emailNotices"
+          android:visibility="gone"/>
+      </LinearLayout>
+    </LinearLayout>
+  </LinearLayout>
+
+  <Button android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:text="@string/continueText"
+    android:textColor="@color/white"
+    android:id="@+id/continueButton"
+    android:layout_gravity="end"
+    style="@style/myButton"
+    android:layout_alignParentBottom="true"
+    android:layout_alignParentRight="true"
+    android:layout_alignParentEnd="true"
+    android:layout_margin="20sp"/>
 </RelativeLayout>


### PR DESCRIPTION
Hi,

I am developing a tool to automatically refactor Android applications with the goal of improving energy efficiency.
This pull request has the changes generated while applying the rule "ObsoleteLayoutParam".

While developing your application's views you might be specifying attributes in a view's artefact that are not necessary due to the nature of its parent. In this PR, those attributes were replaced by a comment.

I have made a previous validation of the changes and they seem correct.
Unfortunately, this tool is not able keep the original whitespace of the files, so comparison without ignoring whitespace might be confusing.
Please consider the changes and let me know if you agree with them.

Best,
Luis