### PR TITLE
Work around an NPE when restoring

### DIFF
--- a/app/src/main/java/com/greenaddress/greenbits/ui/TabbedMainActivity.java
+++ b/app/src/main/java/com/greenaddress/greenbits/ui/TabbedMainActivity.java
@@ -327,14 +327,15 @@ public class TabbedMainActivity extends GaActivity implements Observer, View.OnC
         mService.addConnectionObserver(this);
         mService.addTwoFactorObserver(mTwoFactorObserver);
 
-        if (mService.isForcedOff()) {
+        final SectionsPagerAdapter adapter = getPagerAdapter();
+
+        if (adapter == null || mService.isForcedOff()) {
             // FIXME: Should pass flag to activity so it shows it was forced logged out
             startActivity(new Intent(this, FirstScreenActivity.class));
             finish();
             return;
         }
 
-        final SectionsPagerAdapter adapter = getPagerAdapter();
         setMenuItemVisible(mMenu, R.id.action_share,
                            adapter != null && adapter.mSelectedPage == 0);
      }
@@ -592,6 +593,8 @@ public class TabbedMainActivity extends GaActivity implements Observer, View.OnC
     }
 
     SectionsPagerAdapter getPagerAdapter() {
+        if (mViewPager == null)
+            return null;
         return (SectionsPagerAdapter) mViewPager.getAdapter();
     }
 


### PR DESCRIPTION
There is an activation path that leaves the main activity alive without
creating the tab view, such that if the app is restored it attempts to
access it and NPEs.

If this occurs, instead of crashing, bounce the user back to re-login.