### PR TITLE
Remove duplicated permission checking code

### DIFF
--- a/app/src/main/java/com/greenaddress/greenbits/ui/GaActivity.java
+++ b/app/src/main/java/com/greenaddress/greenbits/ui/GaActivity.java
@@ -2,6 +2,7 @@ package com.greenaddress.greenbits.ui;
 
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
@@ -170,5 +171,13 @@ public abstract class GaActivity extends AppCompatActivity {
                 }
                 break;
         }
+    }
+
+    protected boolean isPermissionGranted(final int[] granted, final int msgId) {
+        if (granted == null || granted.length == 0 || granted[0] != PackageManager.PERMISSION_GRANTED) {
+            shortToast(msgId);
+            return false;
+        }
+        return true;
     }
 }

--- a/app/src/main/java/com/greenaddress/greenbits/ui/MnemonicActivity.java
+++ b/app/src/main/java/com/greenaddress/greenbits/ui/MnemonicActivity.java
@@ -384,16 +384,9 @@ public class MnemonicActivity extends LoginActivity implements View.OnClickListe
     }
 
     @Override
-    public void onRequestPermissionsResult(final int requestCode, final String[] permissions, final int[] grantResults) {
-        if (requestCode != CAMERA_PERMISSION)
-            return;
-
-        if (grantResults[0] != PackageManager.PERMISSION_GRANTED) {
-            shortToast(R.string.err_qrscan_requires_camera_permissions);
-            return;
-        }
-
-        final Intent scanner = new Intent(MnemonicActivity.this, ScanActivity.class);
-        startActivityForResult(scanner, QRSCANNER);
+    public void onRequestPermissionsResult(final int requestCode, final String[] permissions, final int[] granted) {
+        if (requestCode == CAMERA_PERMISSION &&
+            isPermissionGranted(granted, R.string.err_qrscan_requires_camera_permissions))
+            startActivityForResult(new Intent(this, ScanActivity.class), QRSCANNER);
     }
 }

--- a/app/src/main/java/com/greenaddress/greenbits/ui/SellActivity.java
+++ b/app/src/main/java/com/greenaddress/greenbits/ui/SellActivity.java
@@ -1,7 +1,6 @@
 package com.greenaddress.greenbits.ui;
 
 import android.content.Intent;
-import android.content.pm.PackageManager;
 import android.nfc.NfcAdapter;
 import android.os.Bundle;
 import android.view.View;
@@ -52,16 +51,9 @@ public class SellActivity extends GaActivity {
 
     @Override
     public void onRequestPermissionsResult(final int requestCode, final String[] permissions, final int[] granted) {
-       if (requestCode == 100)
-            handlePermissionResult(granted, TabbedMainActivity.REQUEST_SEND_QR_SCAN_EXCHANGER,
-                    R.string.err_qrscan_requires_camera_permissions);
-    }
-
-    // FIXME duplicated function in TabbedMainActivity
-    private void handlePermissionResult(final int[] granted, final int action, final int msgId) {
-        if (granted[0] == PackageManager.PERMISSION_GRANTED)
-            startActivityForResult(new Intent(this, ScanActivity.class), action);
-        else
-            shortToast(msgId);
+       if (requestCode == 100 &&
+           isPermissionGranted(granted, R.string.err_qrscan_requires_camera_permissions))
+            startActivityForResult(new Intent(this, ScanActivity.class),
+                                   TabbedMainActivity.REQUEST_SEND_QR_SCAN_EXCHANGER);
     }
 }

--- a/app/src/main/java/com/greenaddress/greenbits/ui/TabbedMainActivity.java
+++ b/app/src/main/java/com/greenaddress/greenbits/ui/TabbedMainActivity.java
@@ -575,21 +575,14 @@ public class TabbedMainActivity extends GaActivity implements Observer, View.OnC
         setMenuItemVisible(mMenu, R.id.network_unavailable, !state.isLoggedIn());
     }
 
-    private void handlePermissionResult(final int[] granted, final int action, final int msgId) {
-        if (granted[0] == PackageManager.PERMISSION_GRANTED)
-            startActivityForResult(new Intent(this, ScanActivity.class), action);
-        else
-            shortToast(msgId);
-    }
-
     @Override
     public void onRequestPermissionsResult(final int requestCode, final String[] permissions, final int[] granted) {
-        if (requestCode == 200)
-                handlePermissionResult(granted, REQUEST_SWEEP_PRIVKEY,
-                                       R.string.err_tabbed_sweep_requires_camera_permissions);
-        else if (requestCode == 100)
-                handlePermissionResult(granted, REQUEST_SEND_QR_SCAN,
-                                       R.string.err_qrscan_requires_camera_permissions);
+        if (requestCode == 200 &&
+            isPermissionGranted(granted, R.string.err_tabbed_sweep_requires_camera_permissions))
+            startActivityForResult(new Intent(this, ScanActivity.class), REQUEST_SWEEP_PRIVKEY);
+        else if (requestCode == 100 &&
+                 isPermissionGranted(granted, R.string.err_qrscan_requires_camera_permissions))
+            startActivityForResult(new Intent(this, ScanActivity.class), REQUEST_SEND_QR_SCAN);
     }
 
     SectionsPagerAdapter getPagerAdapter() {


### PR DESCRIPTION
Also check the granted permissions to prevent crashes on broken Android
versions that don't return an array matching the one we passed.