### PR TITLE
Standardise and share code to prevent crashes when restoring preferences

### DIFF
--- a/app/src/main/java/com/greenaddress/greenbits/ui/preferences/ExchangerPreferenceFragment.java
+++ b/app/src/main/java/com/greenaddress/greenbits/ui/preferences/ExchangerPreferenceFragment.java
@@ -4,6 +4,7 @@ import android.os.Bundle;
 import android.preference.EditTextPreference;
 import android.preference.Preference;
 import android.text.InputType;
+import android.util.Log;
 import android.widget.Toast;
 
 import com.greenaddress.greenbits.GaService;
@@ -15,7 +16,7 @@ import org.bitcoinj.core.Coin;
 
 public class ExchangerPreferenceFragment extends GAPreferenceFragment implements Preference.OnPreferenceChangeListener {
 
-
+    private static final String TAG = ExchangerPreferenceFragment.class.getSimpleName();
     private EditTextPreference mBuyCommissionPerc;
     private EditTextPreference mBuyCommissionFixed;
     private EditTextPreference mSellCommissionPerc;
@@ -26,8 +27,8 @@ public class ExchangerPreferenceFragment extends GAPreferenceFragment implements
     public void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        if (mService == null) {
-            // Logged out, let our holding activity bounce us back to login
+        if (!verifyServiceOK()) {
+            Log.d(TAG, "Avoiding create on logged out service");
             return;
         }
 

--- a/app/src/main/java/com/greenaddress/greenbits/ui/preferences/GAPreferenceFragment.java
+++ b/app/src/main/java/com/greenaddress/greenbits/ui/preferences/GAPreferenceFragment.java
@@ -4,12 +4,16 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.preference.Preference;
 import android.preference.PreferenceFragment;
+import android.util.Log;
 import android.view.MenuItem;
 
 import com.greenaddress.greenbits.GaService;
 import com.greenaddress.greenbits.GreenAddressApplication;
+import com.greenaddress.greenbits.ui.R;
 
 public class GAPreferenceFragment extends PreferenceFragment {
+    private static final String TAG = GAPreferenceFragment.class.getSimpleName();
+
     protected GaService mService;
 
     @Override
@@ -56,5 +60,21 @@ public class GAPreferenceFragment extends PreferenceFragment {
 
     protected void removePreference(final String preferenceName) {
         removePreference(findPreference(preferenceName));
+    }
+
+    protected boolean verifyServiceOK() {
+        if (mService == null || !mService.isLoggedIn()) {
+            // If we are restored and our service has not been destroyed, its
+            // state is unreliable and our parent activity should shortly
+            // be calling finish(). Avoid accessing the service in this case,
+            // and help the activity along in case it needs prompting to die.
+            final GaPreferenceActivity activity = (GaPreferenceActivity) getActivity();
+            if (activity != null) {
+                activity.toast(R.string.err_send_not_connected_will_resume);
+                activity.finish();
+            }
+            return false;
+        }
+        return true;
     }
 }

--- a/app/src/main/java/com/greenaddress/greenbits/ui/preferences/GeneralPreferenceFragment.java
+++ b/app/src/main/java/com/greenaddress/greenbits/ui/preferences/GeneralPreferenceFragment.java
@@ -35,10 +35,7 @@ public class GeneralPreferenceFragment extends GAPreferenceFragment
     public void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        if (mService == null || !mService.isLoggedIn()) {
-            // If we are restored and our service has not been destroyed, its
-            // state is unreliable and our parent activity should shortly
-            // be calling finish(). Avoid accessing the service in this case.
+        if (!verifyServiceOK()) {
             Log.d(TAG, "Avoiding create on logged out service");
             return;
         }

--- a/app/src/main/java/com/greenaddress/greenbits/ui/preferences/NetworkPreferenceFragment.java
+++ b/app/src/main/java/com/greenaddress/greenbits/ui/preferences/NetworkPreferenceFragment.java
@@ -5,6 +5,7 @@ import android.annotation.TargetApi;
 import android.os.Build;
 import android.os.Bundle;
 import android.preference.Preference;
+import android.util.Log;
 
 import com.greenaddress.greenapi.Network;
 import com.greenaddress.greenbits.ui.R;
@@ -15,9 +16,17 @@ import com.greenaddress.greenbits.ui.R;
  */
 @TargetApi(Build.VERSION_CODES.HONEYCOMB)
 public class NetworkPreferenceFragment extends GAPreferenceFragment {
+    private static final String TAG = GAPreferenceFragment.class.getSimpleName();
+
     @Override
     public void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+
+        if (!verifyServiceOK()) {
+            Log.d(TAG, "Avoiding create on logged out service");
+            return;
+        }
+
         addPreferencesFromResource(R.xml.pref_network);
         setHasOptionsMenu(true);
 

--- a/app/src/main/java/com/greenaddress/greenbits/ui/preferences/SPVPreferenceFragment.java
+++ b/app/src/main/java/com/greenaddress/greenbits/ui/preferences/SPVPreferenceFragment.java
@@ -5,6 +5,7 @@ import android.os.Bundle;
 import android.preference.CheckBoxPreference;
 import android.preference.EditTextPreference;
 import android.preference.Preference;
+import android.util.Log;
 import android.widget.Toast;
 
 import com.afollestad.materialdialogs.DialogAction;
@@ -17,6 +18,7 @@ public class SPVPreferenceFragment extends GAPreferenceFragment
     implements Preference.OnPreferenceChangeListener,
                Preference.OnPreferenceClickListener {
 
+    private static final String TAG = GAPreferenceFragment.class.getSimpleName();
     private EditTextPreference mTrustedPeer;
     private Preference mResetSPV;
     private CheckBoxPreference mSPVEnabled;
@@ -25,6 +27,12 @@ public class SPVPreferenceFragment extends GAPreferenceFragment
     @Override
     public void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+
+        if (!verifyServiceOK()) {
+            Log.d(TAG, "Avoiding create on logged out service");
+            return;
+        }
+
         addPreferencesFromResource(R.xml.preference_spv);
         setHasOptionsMenu(true);
 
@@ -33,9 +41,8 @@ public class SPVPreferenceFragment extends GAPreferenceFragment
         mSPVEnabled = find("spvEnabled");
         mSPVSyncOnMobile = find("spvSyncMobile");
 
-        if (mService == null || mService.isWatchOnly()) {
-            // Do not allow editing of SPV prefs from watch only logins or if we
-            // have been locked out (let our holding activity bounce us back to login)
+        if (mService.isWatchOnly()) {
+            // Do not allow editing of SPV prefs from watch only logins
             mTrustedPeer.setEnabled(false);
             mResetSPV.setEnabled(false);
             mSPVEnabled.setEnabled(false);

--- a/app/src/main/java/com/greenaddress/greenbits/ui/preferences/TwoFactorPreferenceFragment.java
+++ b/app/src/main/java/com/greenaddress/greenbits/ui/preferences/TwoFactorPreferenceFragment.java
@@ -9,6 +9,7 @@ import android.preference.EditTextPreference;
 import android.preference.Preference;
 import android.text.InputType;
 import android.text.TextUtils;
+import android.util.Log;
 import android.view.View;
 import android.widget.ArrayAdapter;
 import android.widget.EditText;
@@ -37,6 +38,7 @@ import java.util.Map;
 public class TwoFactorPreferenceFragment extends GAPreferenceFragment
     implements Preference.OnPreferenceClickListener {
 
+    private static final String TAG = GAPreferenceFragment.class.getSimpleName();
     private static final int REQUEST_ENABLE_2FA = 0;
     private static final String NLOCKTIME_EMAILS = "NLocktimeEmails";
 
@@ -76,6 +78,11 @@ public class TwoFactorPreferenceFragment extends GAPreferenceFragment
     public void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
+        if (!verifyServiceOK()) {
+            Log.d(TAG, "Avoiding create on logged out service");
+            return;
+        }
+
         mLocalizedMap = UI.getTwoFactorLookup(getResources());
 
         addPreferencesFromResource(R.xml.preference_twofactor);
@@ -83,6 +90,7 @@ public class TwoFactorPreferenceFragment extends GAPreferenceFragment
 
         final Map<?, ?> twoFacConfig = mService == null ? null : mService.getTwoFactorConfig();
         if (twoFacConfig == null || twoFacConfig.isEmpty()) {
+            // An additional check to verifyServiceOK: We must have our 2fa data
             final GaPreferenceActivity activity = (GaPreferenceActivity) getActivity();
             if (activity != null) {
                 activity.toast(R.string.err_send_not_connected_will_resume);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -210,7 +210,7 @@
     <string name="set2FA">SETUP 2FA</string>
     <string name="resetSPV">Reset SPV</string>
     <string name="err_send_invalid_bitcoin_uri">Invalid Bitcoin URI</string>
-    <string name="err_send_not_connected_will_resume">Not connected, connection will resume automatically</string>
+    <string name="err_send_not_connected_will_resume">Unable to contact the GreenAddress service. Please check your network connection and wait to be reconnected.</string>
     <string name="err_send_need_recipient">Please provide a recipient</string>
     <string name="err_request_login_no_pin">No PIN provided, exiting.</string>
     <string name="err_tabbed_sweep_failed">Verification failed: Invalid output address</string>


### PR DESCRIPTION
When connectivity is lost or the app is restored without a
service/connection, this bumps the user back to the main activity from
settings instead of crashing.