### PR TITLE
Hardware wallet updates

### DIFF
--- a/app/src/main/java/com/greenaddress/greenbits/ui/RequestLoginActivity.java
+++ b/app/src/main/java/com/greenaddress/greenbits/ui/RequestLoginActivity.java
@@ -151,8 +151,8 @@ public class RequestLoginActivity extends LoginActivity implements OnDiscoveredT
         boolean isFirmwareOutdated = false;
         if (t.getVendorId() == VENDOR_TREZOR) {
             isFirmwareOutdated = version.get(0) < 1 ||
-                                 (version.get(0) == 1 && version.get(1) < 5) ||
-                                 (version.get(0) == 1 && version.get(1) == 5 && version.get(2) < 2);
+                                 (version.get(0) == 1 && version.get(1) < 6) ||
+                                 (version.get(0) == 1 && version.get(1) == 6 && version.get(2) < 0);
         }
 
         if (isFirmwareOutdated) {

--- a/app/src/main/java/com/greenaddress/greenbits/ui/RequestLoginActivity.java
+++ b/app/src/main/java/com/greenaddress/greenbits/ui/RequestLoginActivity.java
@@ -145,7 +145,7 @@ public class RequestLoginActivity extends LoginActivity implements OnDiscoveredT
         if (t == null)
             return false;
 
-        final int VENDOR_TREZOR = 21324, VENDOR_KEEPKEY = 11044;
+        final int VENDOR_TREZOR = 21324;
 
         final List<Integer> version = t.getFirmwareVersion();
         boolean isFirmwareOutdated = false;
@@ -154,8 +154,6 @@ public class RequestLoginActivity extends LoginActivity implements OnDiscoveredT
                                  (version.get(0) == 1 && version.get(1) < 5) ||
                                  (version.get(0) == 1 && version.get(1) == 5 && version.get(2) < 2);
         }
-        if (t.getVendorId() == VENDOR_KEEPKEY && version.get(0) < 4)
-            isFirmwareOutdated = true;
 
         if (isFirmwareOutdated) {
             final TextView instructions = UI.find(this, R.id.firstLoginRequestedInstructionsText);
@@ -211,7 +209,7 @@ public class RequestLoginActivity extends LoginActivity implements OnDiscoveredT
         final TextView edit = UI.find(this, R.id.firstLoginRequestedInstructionsText);
         UI.clear(edit);
         UI.hide(edit);
-        // not TREZOR/KeepKey/BWALLET/AvalonWallet, so must be BTChip
+        // not TREZOR/BWALLET/AvalonWallet, so must be BTChip
         if (mTag != null)
             showPinDialog();
         else {

--- a/app/src/main/java/com/satoshilabs/trezor/Trezor.java
+++ b/app/src/main/java/com/satoshilabs/trezor/Trezor.java
@@ -96,8 +96,9 @@ public class Trezor {
         final UsbManager manager = (UsbManager)context.getSystemService(Context.USB_SERVICE);
 
         for (final UsbDevice device: manager.getDeviceList().values()) {
-            // Check if the device is TREZOR (or AvalonWallet or BWALLET) or KeepKey
-            if (((device.getVendorId() != 0x534c && device.getVendorId() != 0x2B24) || device.getProductId() != 0x0001) &&
+            // Check if the device is TREZOR (or AvalonWallet or BWALLET)
+
+            if ((device.getVendorId() != 0x534c || device.getProductId() != 0x0001) &&
                     (device.getVendorId() != 0x10c4 || device.getProductId() != 0xea80)) {
                 continue;
             }

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -94,7 +94,7 @@
     <string name="main_account">الصفحة الرئيسية</string>
     <string name="footerAccount">الحساب</string>
     <string name="btchipProvidePIN">يرجى تقديم BTChip PIN الخاص بك:</string>
-    <string name="firstLoginRequestedInstructionsOldTrezor">نظام تشغيل Hardware Wallet قديم . الرجاء الترقية إلى 1.5.2 على الأقل في http://mytrezor.com/ من جهاز الكمبيوتر الخاص بك.</string>
+    <string name="firstLoginRequestedInstructionsOldTrezor">نظام تشغيل Hardware Wallet قديم . الرجاء الترقية إلى 1.6.0 على الأقل في http://mytrezor.com/ من جهاز الكمبيوتر الخاص بك.</string>
     <string name="btchipInvalidPIN">PIN غير صالح: %d . محاولة المتبقية: يرجى إعادة الاتصال بالBTChip الخاص بك قبل المحاولة مرة أخرى.</string>
     <string name="btchipNotSetup">لم يتم تعيين BTChip . يرجى إعداده باستخدام عميل سطح المكتب ليكون قادرا على استخدامها.</string>
     <string name="instantConfirmation">تأكيد فوري</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -92,7 +92,7 @@
     <string name="main_account">Hauptkonto</string>
     <string name="footerAccount">Konto</string>
     <string name="btchipProvidePIN">Bitte BTChip PIN eingeben:</string>
-    <string name="firstLoginRequestedInstructionsOldTrezor">Ihre Hardware Wallet firmware ist veraltet. Bitte aktualisieren sie, von ihrem Computer aus, auf Version 1.5.2 oder neuer über http://mytrezor.com/ .</string>
+    <string name="firstLoginRequestedInstructionsOldTrezor">Ihre Hardware Wallet firmware ist veraltet. Bitte aktualisieren sie, von ihrem Computer aus, auf Version 1.6.0 oder neuer über http://mytrezor.com/ .</string>
     <string name="btchipInvalidPIN">Ungültige PIN. Verbleibende Versuche: %d. Bitte Verbinden sie ihren BTChip erneut und versuchen es nochmals.</string>
     <string name="btchipNotSetup">BTChip ist nicht eingerichtet. Bitte nehmen sie alle Einstellungen am Desktop-Client vor um ihren BTChip benutzen zu können.</string>
     <string name="instantConfirmation">Sofortige Bestätigung</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -96,7 +96,7 @@
     <string name="main_account">Principal</string>
     <string name="footerAccount">Cuenta</string>
     <string name="btchipProvidePIN">Por favor, ingrese el PIN de su BTChip:</string>
-    <string name="firstLoginRequestedInstructionsOldTrezor">Firmware de Hardware Wallet desactualizado. Por favor, actualice hasta al menos la versión 1.5.2 en http://mytrezor.com/ desde su computadora.</string>
+    <string name="firstLoginRequestedInstructionsOldTrezor">Firmware de Hardware Wallet desactualizado. Por favor, actualice hasta al menos la versión 1.6.0 en http://mytrezor.com/ desde su computadora.</string>
     <string name="btchipInvalidPIN">PIN inválido. Intentos restantes: %d. Por favor, reconecte su BTChip antes de intentar nuevamente.</string>
     <string name="btchipNotSetup">BTChip no se encuentra configurado. Por favor, configúrelo usando el cliente de escritorio para poder utilizarlo.</string>
     <string name="instantConfirmation">Confirmación instantánea</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -96,7 +96,7 @@
     <string name="main_account">Principal</string>
     <string name="footerAccount">Compte</string>
     <string name="btchipProvidePIN">Veuillez saisir le code PIN de votre BTChip :</string>
-    <string name="firstLoginRequestedInstructionsOldTrezor">Le micrologiciel du portefeuille matériel est dépassé. Veuillez au moins le mettre à jour vers la version 1.5.2 sur http://mytrezor.com/ depuis votre ordinateur.</string>
+    <string name="firstLoginRequestedInstructionsOldTrezor">Le micrologiciel du portefeuille matériel est dépassé. Veuillez au moins le mettre à jour vers la version 1.6.0 sur http://mytrezor.com/ depuis votre ordinateur.</string>
     <string name="btchipInvalidPIN">Code PIN incorrect. Tentatives restantes : %d. Veuillez reconnecter votre BTChip avant de recommencer.</string>
     <string name="btchipNotSetup">Votre BTChip n\'est pas initialisé. Veuillez l\'initialiser depuis votre ordinateur pour l\'utiliser.</string>
     <string name="instantConfirmation">Confirmation instantanée</string>

--- a/app/src/main/res/values-he/strings.xml
+++ b/app/src/main/res/values-he/strings.xml
@@ -96,7 +96,7 @@
     <string name="main_account">ראשי</string>
     <string name="footerAccount">חשבון</string>
     <string name="btchipProvidePIN">יש להכניס קוד PIN של BTChip:</string>
-    <string name="firstLoginRequestedInstructionsOldTrezor">גרסת טרזור ישנה. יש לעדכן לגרסה 1.5.2 לפחות באתר http://mytrezor.com/ מהמחשב.</string>
+    <string name="firstLoginRequestedInstructionsOldTrezor">גרסת טרזור ישנה. יש לעדכן לגרסה 1.6.0 לפחות באתר http://mytrezor.com/ מהמחשב.</string>
     <string name="btchipInvalidPIN">קוד PIN שגוי. נסיונות נותרים: %d. אנא חברו מחדש את ההתקן לפני נסיון נוסף.</string>
     <string name="btchipNotSetup">התקן לא מוכן. אנא הגדירו אותו באמצעות תוכנת המחשב בכדי להשתמש בו.</string>
     <string name="instantConfirmation">אישור מיידי</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -90,7 +90,7 @@
     <string name="main_account">Principale</string>
     <string name="footerAccount">Conto</string>
     <string name="btchipProvidePIN">Digita il tuo PIN per BTChip:</string>
-    <string name="firstLoginRequestedInstructionsOldTrezor">Rilevato Hardware Wallet firmware obsoleto. Per piacere fai un aggiornamento almeno a 1.5.2 da http://mytrezor.com/ dal tuo PC.</string>
+    <string name="firstLoginRequestedInstructionsOldTrezor">Rilevato Hardware Wallet firmware obsoleto. Per piacere fai un aggiornamento almeno a 1.6.0 da http://mytrezor.com/ dal tuo PC.</string>
     <string name="btchipInvalidPIN">PIN incorretto. Tentativi rimasti: %d. Per piacere ricollega il tuo Btchip prima di riprovare.</string>
     <string name="btchipNotSetup">BTChip non è inizializzato. Per piacere inizializzalo sul tuo desktop/laptop.</string>
     <string name="instantConfirmation">Conferma istantanea</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -97,7 +97,7 @@
     <string name="main_account">ראשי</string>
     <string name="footerAccount">חשבון</string>
     <string name="btchipProvidePIN">יש להכניס קוד PIN של BTChip:</string>
-    <string name="firstLoginRequestedInstructionsOldTrezor">גרסת טרזור ישנה. יש לעדכן לגרסה 1.5.2 לפחות באתר http://mytrezor.com/ מהמחשב.</string>
+    <string name="firstLoginRequestedInstructionsOldTrezor">גרסת טרזור ישנה. יש לעדכן לגרסה 1.6.0 לפחות באתר http://mytrezor.com/ מהמחשב.</string>
     <string name="btchipInvalidPIN">קוד PIN שגוי. נסיונות נותרים: %d. אנא חברו מחדש את ההתקן לפני נסיון נוסף.</string>
     <string name="btchipNotSetup">התקן לא מוכן. אנא הגדירו אותו באמצעות תוכנת המחשב בכדי להשתמש בו.</string>
     <string name="instantConfirmation">אישור מיידי</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -94,7 +94,7 @@
     <string name="main_account">Principal</string>
     <string name="footerAccount">Conta</string>
     <string name="btchipProvidePIN">Por favor, forneça o seu PIN BTChip:</string>
-    <string name="firstLoginRequestedInstructionsOldTrezor">O firmware de Hardware Wallet está desatualizado. Faça o upgrade, pelo menos, para a versão 1.5.2 em http://mytrezor.com/ no seu computador.</string>
+    <string name="firstLoginRequestedInstructionsOldTrezor">O firmware de Hardware Wallet está desatualizado. Faça o upgrade, pelo menos, para a versão 1.6.0 em http://mytrezor.com/ no seu computador.</string>
     <string name="btchipInvalidPIN">PIN inválido. Tentativas restantes: %1$d. Por favor, reconecte seu BTChip antes de tentar novamente.</string>
     <string name="btchipNotSetup">BTChip não está configurado. Por favor, configure-o usando um cliente de desktop para ser capaz de usá-lo.</string>
     <string name="instantConfirmation">Confirmação Imediata</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -102,7 +102,7 @@
     <string name="main_account">Основной</string>
     <string name="footerAccount">Аккаунт</string>
     <string name="btchipProvidePIN">Пожалуйста введите Ваш ПИН BTChip:</string>
-    <string name="firstLoginRequestedInstructionsOldTrezor">ПО Вашего Физического Кошелька устарело. Пожалуйста обновите его к, как минимум, 1.5.2 по адресу http://mytrezor.com/ с Вашего компьютера.</string>
+    <string name="firstLoginRequestedInstructionsOldTrezor">ПО Вашего Физического Кошелька устарело. Пожалуйста обновите его к, как минимум, 1.6.0 по адресу http://mytrezor.com/ с Вашего компьютера.</string>
     <string name="firstLoginRequestedPleaseOpenBitcoinApp">Детектировано Ledger Dashboard, Пожалуйста откройте приложение Bitcoin для доступа.</string>
     <string name="btchipInvalidPIN">ПИН некоректный. Осталось %1$d попыток. Пожалуйста переподсоедините ваш BTChip перед следуйщей попыткой.</string>
     <string name="btchipNotSetup">BTChip не установлен. Пожалуйста установите его на дектоп клиент для использование.</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -102,7 +102,7 @@
     <string name="main_account">Основний</string>
     <string name="footerAccount">Аккаунт</string>
     <string name="btchipProvidePIN">Будь-ласка введіть Ваш ПІН BTChip:</string>
-    <string name="firstLoginRequestedInstructionsOldTrezor">ПЗ Вашого Фізичного Гаманця застаріло. Будь-ласка обновіть його до, як мінімум, 1.5.2 за адресою http://mytrezor.com/ з вашого комп\'ютера.</string>
+    <string name="firstLoginRequestedInstructionsOldTrezor">ПЗ Вашого Фізичного Гаманця застаріло. Будь-ласка обновіть його до, як мінімум, 1.6.0 за адресою http://mytrezor.com/ з вашого комп\'ютера.</string>
     <string name="firstLoginRequestedPleaseOpenBitcoinApp">Детектовано Ledger Dashboard, будь-ласка відкрийте додаток Bitcoin для доступу.</string>
     <string name="btchipInvalidPIN">ПІН некоректний. Залишилось %1$d спроб. Будь-ласка перепідєднайте ваш BTChip перед наступною спробою.</string>
     <string name="btchipNotSetup">BTChip не встановлений. Будь-ласка встановіть його на дектоп клієнті для використання.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -158,7 +158,7 @@
     <string name="main_account">Main</string>
     <string name="footerAccount">Account</string>
     <string name="btchipProvidePIN">Please provide your BTChip PIN:</string>
-    <string name="firstLoginRequestedInstructionsOldTrezor">Outdated Hardware Wallet firmware. Please upgrade to at least 1.5.2 at http://mytrezor.com/ from your computer.</string>
+    <string name="firstLoginRequestedInstructionsOldTrezor">Outdated Hardware Wallet firmware. Please upgrade to at least 1.6.0 at http://mytrezor.com/ from your computer.</string>
     <string name="firstLoginRequestedPleaseOpenBitcoinApp">Ledger Dashboard detected, please open the Bitcoin app to access.</string>
     <string name="btchipInvalidPIN">Invalid PIN. Remaining attempts: %1$d. Please reconnect your BTChip before trying again.</string>
     <string name="btchipNotSetup">BTChip is not set up. Please set it up using a desktop client to be able to use it.</string>

--- a/app/src/main/res/xml/device_filter.xml
+++ b/app/src/main/res/xml/device_filter.xml
@@ -2,8 +2,6 @@
 <resources>
     <!-- VID 0x534c PID 0x0001 - TREZOR, BWALLET, AvalonWallet -->
     <usb-device vendor-id="21324" product-id="1" />
-    <!-- VID 0x2B24 PID 0x0001 - KeepKey -->
-    <usb-device vendor-id="11044" product-id="1" />
     <!-- VID 0x10c4 PID 0xea80 - TREZOR rpi bridge  -->
     <usb-device vendor-id="4292" product-id="60032" />
 


### PR DESCRIPTION
- remove support for keepkey
- update min version of trezor to 1.6.0 (note: 1.6.1 is released but not via the Android Trezor manager yet)