### PR TITLE
Don't fall through to BIP70 logic when sending non-BIP70 txs

### DIFF
--- a/app/src/main/java/com/greenaddress/greenbits/ui/SendFragment.java
+++ b/app/src/main/java/com/greenaddress/greenbits/ui/SendFragment.java
@@ -1169,6 +1169,7 @@ public class SendFragment extends SubaccountFragment {
                 if (mPayreqData == null) {
                     UI.dismiss(gaActivity, SendFragment.this.mSummary);
                     onTransactionSent();
+                    return;
                 }
                 final PaymentSession session;
                 try {


### PR DESCRIPTION
This prevents (otherwise harmless) errors in the log.