### PR TITLE
Remove old manual checking for connectivity on pin login

### DIFF
--- a/app/src/main/java/com/greenaddress/greenbits/ui/PinActivity.java
+++ b/app/src/main/java/com/greenaddress/greenbits/ui/PinActivity.java
@@ -223,14 +223,7 @@ public class PinActivity extends LoginActivity implements Observer, View.OnClick
             Futures.addCallback(mService.onConnected, new FutureCallback<Void>() {
                 @Override
                 public void onSuccess(final Void result) {
-
-                    if (mService.isConnected()) {
-                        setUpLogin(pin, null);
-                        return;
-                    }
-
-                    // try again
-                    tryDecrypt();
+                    setUpLogin(pin, null);
                 }
 
                 @Override


### PR DESCRIPTION
The pin login code already handles disconnection correctly by closing the activity so this should prevent UI timeout crashes.