### PR TITLE
Passwords should be invisible to the accessibility services

### DIFF
--- a/app/src/main/res/layout/activity_mnemonic.xml
+++ b/app/src/main/res/layout/activity_mnemonic.xml
@@ -57,6 +57,7 @@
                     android:imeActionLabel="@android:string/ok"
                     android:imeOptions="actionGo"
                     android:inputType="textMultiLine|textVisiblePassword"
+                    android:importantForAccessibility="no"
                     android:minLines="2"
                     android:digits="abcdefghijklmnopqrstuvwxyz "
                     android:text=""

--- a/app/src/main/res/layout/activity_pin.xml
+++ b/app/src/main/res/layout/activity_pin.xml
@@ -37,6 +37,7 @@
             android:textColor="@color/secondaryTextColor"
             android:textSize="34sp"
             android:inputType="numberPassword"
+            android:importantForAccessibility="no"
         />
         <requestFocus />
     </android.support.design.widget.TextInputLayout>

--- a/app/src/main/res/layout/activity_pin_save.xml
+++ b/app/src/main/res/layout/activity_pin_save.xml
@@ -34,6 +34,7 @@
             android:gravity="center"
             android:hint=""
             android:inputType="numberPassword"
+            android:importantForAccessibility="no"
             android:maxLength="15"
             android:textColor="@color/secondaryTextColor"
             android:textSize="34sp"

--- a/app/src/main/res/layout/activity_watchonly.xml
+++ b/app/src/main/res/layout/activity_watchonly.xml
@@ -37,6 +37,7 @@
                 android:layout_height="wrap_content"
                 android:hint="@string/password"
                 android:inputType="textPassword"
+                android:importantForAccessibility="no"
                 />
         </android.support.design.widget.TextInputLayout>
 

--- a/app/src/main/res/layout/dialog_btchip_pin.xml
+++ b/app/src/main/res/layout/dialog_btchip_pin.xml
@@ -23,7 +23,8 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:textColor="@color/whiteSecondary"
-            android:inputType="numberPassword" />
+            android:inputType="numberPassword"
+            android:importantForAccessibility="no" />
     </android.support.design.widget.TextInputLayout>
 
 </LinearLayout>

--- a/app/src/main/res/layout/dialog_new_transaction.xml
+++ b/app/src/main/res/layout/dialog_new_transaction.xml
@@ -117,6 +117,7 @@
         android:textColor="@color/whiteSecondary"
         android:visibility="gone"
         android:inputType="numberPassword"
+        android:importantForAccessibility="no"
         android:imeOptions="actionSend" />
 
 

--- a/app/src/main/res/layout/dialog_nfc_write.xml
+++ b/app/src/main/res/layout/dialog_nfc_write.xml
@@ -45,6 +45,7 @@
         android:layout_height="wrap_content"
         android:layout_marginTop="4dp"
         android:textColor="@color/whiteSecondary"
-        android:inputType="textPassword" />
+        android:inputType="textPassword"
+        android:importantForAccessibility="no" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/dialog_passphrase.xml
+++ b/app/src/main/res/layout/dialog_passphrase.xml
@@ -24,6 +24,7 @@
             android:layout_height="wrap_content"
             android:textColor="@color/white"
             android:inputType="textPassword"
+            android:importantForAccessibility="no"
             />
         <requestFocus />
     </android.support.design.widget.TextInputLayout>

--- a/app/src/main/res/layout/dialog_set_watchonly.xml
+++ b/app/src/main/res/layout/dialog_set_watchonly.xml
@@ -37,6 +37,7 @@
             android:layout_height="wrap_content"
             android:textColor="@color/white"
             android:inputType="textPassword"
+            android:importantForAccessibility="no"
             />
     </android.support.design.widget.TextInputLayout>
 

--- a/app/src/main/res/layout/dialog_sweep_address.xml
+++ b/app/src/main/res/layout/dialog_sweep_address.xml
@@ -36,6 +36,7 @@
         android:layout_height="wrap_content"
         android:layout_marginTop="4dp"
         android:inputType="textPassword"
+        android:importantForAccessibility="no"
         android:textColor="@color/whiteSecondary" />
 
 

--- a/app/src/main/res/layout/dialog_trezor_passphrase.xml
+++ b/app/src/main/res/layout/dialog_trezor_passphrase.xml
@@ -21,7 +21,8 @@
             android:id="@+id/trezorPassphraseValue"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:inputType="textPassword" />
+            android:inputType="textPassword"
+            android:importantForAccessibility="no" />
     </android.support.design.widget.TextInputLayout>
 
 </LinearLayout>

--- a/app/src/main/res/layout/dialog_trezor_pin.xml
+++ b/app/src/main/res/layout/dialog_trezor_pin.xml
@@ -66,6 +66,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:inputType="numberPassword"
+            android:importantForAccessibility="no"
             android:editable="false"  />
     </android.support.design.widget.TextInputLayout>
 


### PR DESCRIPTION
Due to recent attacks, malicious apps that are using the accessibility service can capture all user inputs. In this case, the passwords should be ignored for the accessibility service, so such attacks cannot happen. This is done by our research project in CISPA, Saarland University, Germany.