### PR TITLE
Disable Android 8 autofill on all EditText

### DIFF
--- a/app/src/main/res/values-v26/styles.xml
+++ b/app/src/main/res/values-v26/styles.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="AppTheme.NoActionBar">
+        <item name="windowActionBar">false</item>
+        <item name="windowNoTitle">true</item>
+        <item name="android:windowDrawsSystemBarBackgrounds">true</item>
+        <item name="android:editTextStyle">@style/EditTextStyle_NoAutofill</item>
+        <item name="editTextStyle">@style/EditTextStyle_NoAutofill</item>
+    </style>
+
+    <style name="AppTheme" parent="AppTheme.Base">
+        <item name="android:textColor">@color/textColor</item>
+        <item name="android:textColorSecondary">@color/secondaryTextColor</item>
+        <item name="android:windowBackground">@color/white</item>
+        <item name="android:colorButtonNormal">@color/accent</item>
+        <item name="android:editTextStyle">@style/EditTextStyle_NoAutofill</item>
+        <item name="editTextStyle">@style/EditTextStyle_NoAutofill</item>
+    </style>
+
+    <style name="EditTextStyle_NoAutofill" parent="@android:style/Widget.EditText">
+        <item name="android:importantForAutofill">noExcludeDescendants</item>
+    </style>
+
+</resources>


### PR DESCRIPTION
Created new style for API 26 and disabled the autofill for all EditText (ref. https://developer.android.com/guide/topics/text/autofill)

This is a proposal, if you prefer eventually we can disable autofill only for a specific fields.